### PR TITLE
Add summarise feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SummariseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummariseCommand.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Faculty;
+import seedu.address.model.person.Person;
+
+/**
+ * Summarise all the students by faculty and show how many students in that faculty are positive, negative, HRW, HRN
+ */
+public class SummariseCommand extends Command {
+
+    public static final String COMMAND_WORD = "summarise";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Summarise all data in the address book and presents an overview of the covid situation in school.\n";
+
+    public static final String MESSAGE_SUMMARISE_PERSON_SUCCESS = "Summarising all students: \n";
+
+    private static final String FACULTY_SUMMARY_FORM = "\nIn %s with %d student(s),\n"
+            + "Covid Positive: %d student(s)\n"
+            + "Covid Negative: %d student(s)\n"
+            + "Health Risk Warning: %d student(s)\n"
+            + "Health Risk Notice: %d student(s)\n"
+            + "%.2f percent of student(s) here are suffering...\n";
+
+    private static final List<String> FACULTIES = Faculty.getFacultyEnumAsList();
+
+    private static final Predicate<Person> BYPOSITIVE = person -> person.getStatusAsString().equals("POSITIVE");
+    private static final Predicate<Person> BYNEGATIVE = person -> person.getStatusAsString().equals("NEGATIVE");
+    private static final Predicate<Person> BYHRW = person -> person.getStatusAsString().equals("HRW");
+    private static final Predicate<Person> BYHRN = person -> person.getStatusAsString().equals("HRN");
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        StringBuilder answer = new StringBuilder(MESSAGE_SUMMARISE_PERSON_SUCCESS);
+
+        for (String facultyName : FACULTIES) {
+            Predicate<Person> byFaculty = person -> person.getFacultyAsString().equals(facultyName);
+            List<Person> students = lastShownList.stream().filter(byFaculty).collect(Collectors.toList());
+            if (students.size() <= 0) {
+                continue;
+            }
+            answer.append(summariseByFaculty(students, facultyName));
+        }
+        return new CommandResult(answer.toString());
+    }
+
+    private String summariseByFaculty(List<Person> result, String facultyName) {
+        int totalNumberOfStudents = result.size();
+        int numberOfPositive = (int) result.stream().filter(BYPOSITIVE).count();
+        int numberOfNegative = (int) result.stream().filter(BYNEGATIVE).count();
+        int numberOfHRW = (int) result.stream().filter(BYHRW).count();
+        int numberOfHRN = (int) result.stream().filter(BYHRN).count();
+        double percentagePositive = (double) numberOfPositive / totalNumberOfStudents * 100;
+
+        return String.format(FACULTY_SUMMARY_FORM, facultyName, totalNumberOfStudents, numberOfPositive,
+                numberOfNegative, numberOfHRW, numberOfHRN, percentagePositive);
+    }
+
+}
+
+

--- a/src/main/java/seedu/address/logic/commands/SummariseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummariseCommand.java
@@ -61,12 +61,12 @@ public class SummariseCommand extends Command {
         int totalNumberOfStudents = result.size();
         int numberOfPositive = (int) result.stream().filter(BYPOSITIVE).count();
         int numberOfNegative = (int) result.stream().filter(BYNEGATIVE).count();
-        int numberOfHRW = (int) result.stream().filter(BYHRW).count();
-        int numberOfHRN = (int) result.stream().filter(BYHRN).count();
+        int numberOfHrw = (int) result.stream().filter(BYHRW).count();
+        int numberOfHrn = (int) result.stream().filter(BYHRN).count();
         double percentagePositive = (double) numberOfPositive / totalNumberOfStudents * 100;
 
         return String.format(FACULTY_SUMMARY_FORM, facultyName, totalNumberOfStudents, numberOfPositive,
-                numberOfNegative, numberOfHRW, numberOfHRN, percentagePositive);
+                numberOfNegative, numberOfHrw, numberOfHrn, percentagePositive);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/SummariseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummariseCommand.java
@@ -33,10 +33,10 @@ public class SummariseCommand extends Command {
 
     private static final List<String> FACULTIES = Faculty.getFacultyEnumAsList();
 
-    private static final Predicate<Person> BYPOSITIVE = person -> person.getStatusAsString().equals("POSITIVE");
-    private static final Predicate<Person> BYNEGATIVE = person -> person.getStatusAsString().equals("NEGATIVE");
-    private static final Predicate<Person> BYHRW = person -> person.getStatusAsString().equals("HRW");
-    private static final Predicate<Person> BYHRN = person -> person.getStatusAsString().equals("HRN");
+    private static final Predicate<Person> BY_POSITIVE = person -> person.getStatusAsString().equals("POSITIVE");
+    private static final Predicate<Person> BY_NEGATIVE = person -> person.getStatusAsString().equals("NEGATIVE");
+    private static final Predicate<Person> BY_HRW = person -> person.getStatusAsString().equals("HRW");
+    private static final Predicate<Person> BY_HRN = person -> person.getStatusAsString().equals("HRN");
 
 
     @Override
@@ -57,12 +57,19 @@ public class SummariseCommand extends Command {
         return new CommandResult(answer.toString());
     }
 
+    /**
+     * Returns a standardised form with the breakdown of students by covid status within a specified faculty.
+     *
+     * @param result a list of students in said faculty
+     * @param facultyName the faculty in which students are from
+     * @return a string form containing the respective number of students with certain covid status
+     */
     private String summariseByFaculty(List<Person> result, String facultyName) {
         int totalNumberOfStudents = result.size();
-        int numberOfPositive = (int) result.stream().filter(BYPOSITIVE).count();
-        int numberOfNegative = (int) result.stream().filter(BYNEGATIVE).count();
-        int numberOfHrw = (int) result.stream().filter(BYHRW).count();
-        int numberOfHrn = (int) result.stream().filter(BYHRN).count();
+        int numberOfPositive = (int) result.stream().filter(BY_POSITIVE).count();
+        int numberOfNegative = (int) result.stream().filter(BY_NEGATIVE).count();
+        int numberOfHrw = (int) result.stream().filter(BY_HRW).count();
+        int numberOfHrn = (int) result.stream().filter(BY_HRN).count();
         double percentagePositive = (double) numberOfPositive / totalNumberOfStudents * 100;
 
         return String.format(FACULTY_SUMMARY_FORM, facultyName, totalNumberOfStudents, numberOfPositive,

--- a/src/main/java/seedu/address/logic/commands/SummariseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummariseCommand.java
@@ -44,17 +44,28 @@ public class SummariseCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         List<Person> lastShownList = model.getFilteredPersonList();
-        StringBuilder answer = new StringBuilder(MESSAGE_SUMMARISE_PERSON_SUCCESS);
+        String answer = MESSAGE_SUMMARISE_PERSON_SUCCESS + filterByFaculty(lastShownList);
+        return new CommandResult(answer);
+    }
+
+    /**
+     * Filter entire list by faculties to provide overview of covid situation in each faculty.
+     *
+     * @param list the unfiltered entire list in the database
+     * @return the summarised overview for all students by faculties
+     */
+    private String filterByFaculty(List<Person> list) {
+        StringBuilder ans = new StringBuilder();
 
         for (String facultyName : FACULTIES) {
             Predicate<Person> byFaculty = person -> person.getFacultyAsString().equals(facultyName);
-            List<Person> students = lastShownList.stream().filter(byFaculty).collect(Collectors.toList());
+            List<Person> students = list.stream().filter(byFaculty).collect(Collectors.toList());
             if (students.size() <= 0) {
                 continue;
             }
-            answer.append(summariseByFaculty(students, facultyName));
+            ans.append(summariseFaculty(students, facultyName));
         }
-        return new CommandResult(answer.toString());
+        return ans.toString();
     }
 
     /**
@@ -64,7 +75,7 @@ public class SummariseCommand extends Command {
      * @param facultyName the faculty in which students are from
      * @return a string form containing the respective number of students with certain covid status
      */
-    private String summariseByFaculty(List<Person> result, String facultyName) {
+    private String summariseFaculty(List<Person> result, String facultyName) {
         int totalNumberOfStudents = result.size();
         int numberOfPositive = (int) result.stream().filter(BY_POSITIVE).count();
         int numberOfNegative = (int) result.stream().filter(BY_NEGATIVE).count();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,15 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +59,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case SummariseCommand.COMMAND_WORD:
+            return new SummariseCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,7 +6,16 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SummariseCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/model/person/Faculty.java
+++ b/src/main/java/seedu/address/model/person/Faculty.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -82,5 +84,14 @@ public class Faculty {
     @Override
     public int hashCode() {
         return studentFaculty.hashCode();
+    }
+
+    /**
+     * Returns a list of strings with enum values from the Nus enum class.
+     *
+     * @return List of Nus enum values.
+     */
+    public static List<String> getFacultyEnumAsList() {
+        return Stream.of(Nus.values()).map(Enum::name).collect(Collectors.toList());
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -67,6 +67,24 @@ public class Person {
         return status;
     }
 
+    /**
+     * Returns the Covid Status as a String instead of type CovidStatus.
+     *
+     * @return a string of the covidStatus
+     */
+    public String getStatusAsString() {
+        return status.toString();
+    }
+
+    /**
+     * Returns the Faculty of this person as a String instead of type Faculty.
+     *
+     * @return a string of the faculty
+     */
+    public String getFacultyAsString() {
+        return faculty.toString();
+    }
+
     public Address getAddress() {
         return address;
     }


### PR DESCRIPTION
Summarise command helps user to have a brief overview of the data they
have. This is helpful to see how many covid cases there are in each
faculty instead of navigating through the entire list.

From the list of students, they are separated by their faculty and the
application will count how many students there are, how many students
with a certain covid status. This is shown to the user.

It is done this way because the list command cannot show a tabulated
data of the student body.