### PR TITLE
Add filter function

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+import seedu.address.model.person.CovidStatus;
+
+/**
+ * Lists all persons in the address book to the user.
+ */
+public class FilterCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons who are of the specified health "
+            + "status (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: [COVID STATUS]...\n"
+            + "Example: " + COMMAND_WORD + " POSITIVE";
+
+    public static final String MESSAGE_SUCCESS = "Listed all persons";
+
+    private CovidStatus status;
+
+    public FilterCommand(String status) {
+        requireNonNull(status);
+
+        this.status = new CovidStatus(status);
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(p -> p.isStatus(status));
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterCommand)) {
+            return false;
+        }
+
+        // state check
+        FilterCommand e = (FilterCommand) other;
+        return status.equals(e.status);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -65,6 +66,9 @@ public class AddressBookParser {
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FilterCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
+
+        return new FilterCommand(trimmedArgs);
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -77,6 +77,16 @@ public class Person {
     }
 
     /**
+     * Predicate to check if the status of Person object matches the given CovidStatus.
+     *
+     * @param status given status to check if matched by status property in Person
+     * @return boolean value to show if there is a match
+     */
+    public boolean isStatus(CovidStatus status) {
+        return this.status.equals(status);
+    }
+
+    /**
      * Returns the Faculty of this person as a String instead of type Faculty.
      *
      * @return a string of the faculty


### PR DESCRIPTION
Added filter command to display a list of contacts filtered by health status, which has to be a valid status in the CovidStatus class.
Created new classes FilterCommand and FilterCommandParser.
Added predicate in Person class that checks if the status attribute of aPerson instance matches input CovidStatus.
Added a new case in AddressBookParser to recognize and parse FilterCommand.

User input format will be `filter [COVID STATUS]`

This is in response to Issue #2 for Milestone v1.2

