### PR TITLE
Filter Test Cases

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -147,11 +147,11 @@ Filter student based on health statuses
 
 Format:`find HEALTH_STATUS`
 
-* Returns a list of students with the given health status: `covid-positive`, `covid-negative`, `close-contact`
-* The search is case-sensitive. e.g `Covid-Positive` will not match `covid-positive`
+* Returns a list of students with the given health status: `positive`, `negative`, `hrw`, `hrn`
+* The search is case-insensitive. e.g `Positive` will match `positive`
 
 Examples of usage:
-* `find covid-positive` returna all student that are tagged as covid-positive
+* `find positive` returns all student that are tagged as covid-positive
 
 ### Saving
 Saving in the application is automatic. The data in the file will be saved accordingly whenever

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.Model;
+import seedu.address.model.person.CovidStatus;
+
+/**
+ * Lists all persons in the address book to the user.
+ */
+public class FilterCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons who are of the specified health "
+            + "status (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: [COVID STATUS]...\n"
+            + "Example: " + COMMAND_WORD + " POSITIVE";
+
+    public static final String MESSAGE_SUCCESS = "Listed all persons";
+
+    private CovidStatus status;
+
+    public FilterCommand(String status) {
+        requireNonNull(status);
+
+        this.status = new CovidStatus(status);
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(p -> p.isStatus(status));
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterCommand)) {
+            return false;
+        }
+
+        // state check
+        FilterCommand e = (FilterCommand) other;
+        return status.equals(e.status);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -21,6 +21,11 @@ public class FilterCommand extends Command {
 
     private CovidStatus status;
 
+    /**
+     * Constructor for this class to create a FilterCommand object.
+     *
+     * @param status input String to create a CovidStatus object and store it in the instance
+     */
     public FilterCommand(String status) {
         requireNonNull(status);
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -6,7 +6,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.CovidStatus;
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists all persons with a specified covid status in the address book to the user.
  */
 public class FilterCommand extends Command {
 
@@ -35,7 +35,7 @@ public class FilterCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(p -> p.isStatus(status));
+        model.updateFilteredPersonList(person -> person.isStatus(status));
         return new CommandResult(MESSAGE_SUCCESS);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -65,6 +66,9 @@ public class AddressBookParser {
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -6,7 +6,7 @@ import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FilterCommand object
  */
 public class FilterCommandParser implements Parser<FilterCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FilterCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
+
+        return new FilterCommand(trimmedArgs);
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -77,6 +77,16 @@ public class Person {
     }
 
     /**
+     * Predicate to check if the status of Person object matches the given CovidStatus.
+     *
+     * @param status given status to check if matched by status property in Person
+     * @return boolean value to show if there is a match
+     */
+    public boolean isStatus(CovidStatus status) {
+        return this.status.equals(status);
+    }
+
+    /**
      * Returns the Faculty of this person as a String instead of type Faculty.
      *
      * @return a string of the faculty

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,80 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.FilterCommand.MESSAGE_SUCCESS;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.CovidStatus;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ */
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private CovidStatus positive = new CovidStatus("positive");
+    private CovidStatus negative = new CovidStatus("negative");
+    private CovidStatus hrw = new CovidStatus("hrw");
+    private CovidStatus hrn = new CovidStatus("hrn");
+
+    @Test
+    public void isStatus_correctOutput() {
+        // correctly matches CovidStatus input -> returns true
+        assertTrue(CARL.isStatus(hrn));
+        assertTrue(ELLE.isStatus(hrw));
+        assertTrue(FIONA.isStatus(negative));
+        assertTrue(GEORGE.isStatus(positive));
+
+        // wrongly matches CovidStatus input -> returns false
+        assertFalse(CARL.isStatus(positive));
+        assertFalse(ELLE.isStatus(negative));
+    }
+
+    @Test
+    public void equals() {
+
+        FilterCommand filterFirstCommand = new FilterCommand("positive");
+        FilterCommand filterSecondCommand = new FilterCommand("hrw");
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand filterFirstCommandCopy = new FilterCommand("positive");
+        assertTrue(filterFirstCommand.equals(filterFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    @Test
+    public void execute_positive_covidPositivePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_SUCCESS);
+        FilterCommand command = new FilterCommand(CovidStatus.CovidStatusTier.POSITIVE.toString());
+        expectedModel.updateFilteredPersonList(person -> person.isStatus(positive));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(DANIEL, GEORGE), model.getFilteredPersonList());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.person.CovidStatus;
+
+public class FilterCommandParserTest {
+
+    private FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FilterCommand expectedFilterCommand =
+                new FilterCommand(CovidStatus.CovidStatusTier.POSITIVE.toString());
+        assertParseSuccess(parser, "positive", expectedFilterCommand);
+
+        // with leading and trailing whitespaces
+        assertParseSuccess(parser, " \n positive  \t", expectedFilterCommand);
+
+        // with varying cases
+        assertParseSuccess(parser, " \n pOsITive  \t", expectedFilterCommand);
+    }
+
+}


### PR DESCRIPTION
Added test cases to test FilterCommand.java and FilterCommandParser.java, by adding FilterCommandTest.java and FilterCommandParserTest.java.

My initially PR to add Filter function did not include tests for both unit and integration testing for both classes, hence this PR is meant to do both types of testing for the 2 classes involved. It is a continuation to my previous PR #50 and should be merged after it. 

100% method and line coverage has been achieved for both FilterCommand and FilterCommandParser classes. 