### PR TITLE
Add test cases for person package

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -90,7 +90,7 @@ Possible tags:
 | `a/` | Address | - |
 | `f/` | Faculty |  FASS, BIZ, SOC, SCALE, FOD, CDE, DUKE, FOL, YLLSOM, YSTCOM, SOPP, LKYSPP, SPH, TEST, FOS |
 | `mc/` | Matriculation Number | - | 
-| `cs`/ | Covid Status | Positive, Negative, HRW, HRN |
+| `cs`/ | Covid Status | Positive, Negative, HRN |
 
 ### Deleting a contact: `delete`
 Delete a contact at a specific index
@@ -133,7 +133,7 @@ to show everyone in the address book while providing a valid response by the app
 Format:`summarise`
 
 Example of usage:
-*  `summarise` summarises the contacts of everyone in the Tracey application such that she responses with how many Covid positive students in faculty A, how many on HRN, HRW and negative.
+*  `summarise` summarises the contacts of everyone in the Tracey application such that she responses with how many Covid positive students in faculty A, how many on HRN and negative.
 
 Future Enhancements:
 *  For future versions, summarise command can display a visual pie chart for different faculties to visualise the percentage of Covid positive students.

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -250,7 +250,7 @@ public class EditCommand extends Command {
 
         /**
          * Set the covid status of a student
-         * @param covidStatus is the covid status of a student in POSITIVE, NEGATIVE, HRW, HRN
+         * @param covidStatus is the covid status of a student in POSITIVE, NEGATIVE, HRN
          */
         public void setCovidStatus(CovidStatus covidStatus) {
             this.covidStatus = covidStatus;

--- a/src/main/java/seedu/address/logic/commands/SummariseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummariseCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.Faculty;
 import seedu.address.model.person.Person;
 
 /**
- * Summarise all the students by faculty and show how many students in that faculty are positive, negative, HRW, HRN
+ * Summarise all the students by faculty and show how many students in that faculty are positive, negative, HRN
  */
 public class SummariseCommand extends Command {
 
@@ -29,7 +29,6 @@ public class SummariseCommand extends Command {
     private static final String FACULTY_SUMMARY_FORM = "\nIn %s with %d student(s),\n"
             + "Covid Positive: %d student(s)\n"
             + "Covid Negative: %d student(s)\n"
-            + "Health Risk Warning: %d student(s)\n"
             + "Health Risk Notice: %d student(s)\n"
             + "%.2f percent of student(s) here are suffering...\n";
 
@@ -37,7 +36,6 @@ public class SummariseCommand extends Command {
 
     private static final Predicate<Person> BY_POSITIVE = person -> person.getStatusAsString().equals("POSITIVE");
     private static final Predicate<Person> BY_NEGATIVE = person -> person.getStatusAsString().equals("NEGATIVE");
-    private static final Predicate<Person> BY_HRW = person -> person.getStatusAsString().equals("HRW");
     private static final Predicate<Person> BY_HRN = person -> person.getStatusAsString().equals("HRN");
 
 
@@ -86,12 +84,11 @@ public class SummariseCommand extends Command {
         int totalNumberOfStudents = result.size();
         int numberOfPositive = (int) result.stream().filter(BY_POSITIVE).count();
         int numberOfNegative = (int) result.stream().filter(BY_NEGATIVE).count();
-        int numberOfHrw = (int) result.stream().filter(BY_HRW).count();
         int numberOfHrn = (int) result.stream().filter(BY_HRN).count();
         double percentagePositive = (double) numberOfPositive / totalNumberOfStudents * 100;
 
         return String.format(FACULTY_SUMMARY_FORM, facultyName, totalNumberOfStudents, numberOfPositive,
-                numberOfNegative, numberOfHrw, numberOfHrn, percentagePositive);
+                numberOfNegative, numberOfHrn, percentagePositive);
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -32,6 +32,9 @@ public class Address {
 
     /**
      * Returns true if a given string is a valid email.
+     *
+     * @param test string to be tested to determine if valid address.
+     * @return Boolean result where it is true if a given string is valid address, false otherwise.
      */
     public static boolean isValidAddress(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/person/Block.java
+++ b/src/main/java/seedu/address/model/person/Block.java
@@ -39,8 +39,9 @@ public class Block {
 
     /**
      * Returns true if a given string is a valid block.
-     * @param test
-     * @return true if a given string is valid, false otherwise.
+     *
+     * @param test string to be tested to determine if valid block.
+     * @return Boolean result where it is true if a given string is a valid block, false otherwise.
      */
     public static boolean isValidBlock(String test) {
         return Stream.of(HallBlock.values())

--- a/src/main/java/seedu/address/model/person/CovidStatus.java
+++ b/src/main/java/seedu/address/model/person/CovidStatus.java
@@ -12,11 +12,10 @@ import java.util.stream.Stream;
 public class CovidStatus {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Covid status should be one of the following: " + getCovidStatusEnumAsString() + ", and it should"
+            "Covid status should be one of the following: " + getCovidStatusEnumAsString() + ", and it should "
                     + "not be blank";
 
     public enum CovidStatusTier {
-        HRW,
         HRN,
         NEGATIVE,
         POSITIVE
@@ -38,13 +37,13 @@ public class CovidStatus {
     /**
      * Returns true if a given string is a valid covid status.
      *
-     * @param test
+     * @param inputStatus
      * @return true if given string is valid, false otherwise.
      */
-    public static boolean isValidCovidStatus(String test) {
+    public static boolean isValidCovidStatus(String inputStatus) {
         return Stream.of(CovidStatusTier.values())
                 .anyMatch(status -> status.name()
-                        .equalsIgnoreCase(test));
+                        .equalsIgnoreCase(inputStatus));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/CovidStatus.java
+++ b/src/main/java/seedu/address/model/person/CovidStatus.java
@@ -37,13 +37,13 @@ public class CovidStatus {
     /**
      * Returns true if a given string is a valid covid status.
      *
-     * @param inputStatus
-     * @return true if given string is valid, false otherwise.
+     * @param test covid status string to be tested.
+     * @return Boolean result where true if given string is a valid status, false otherwise.
      */
-    public static boolean isValidCovidStatus(String inputStatus) {
+    public static boolean isValidCovidStatus(String test) {
         return Stream.of(CovidStatusTier.values())
                 .anyMatch(status -> status.name()
-                        .equalsIgnoreCase(inputStatus));
+                        .equalsIgnoreCase(test));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -46,6 +46,9 @@ public class Email {
 
     /**
      * Returns if a given string is a valid email.
+     *
+     * @param test string to be tested to determine if valid email.
+     * @return Boolean result where it is true if a given string is a valid email, false otherwise.
      */
     public static boolean isValidEmail(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/person/Faculty.java
+++ b/src/main/java/seedu/address/model/person/Faculty.java
@@ -49,8 +49,9 @@ public class Faculty {
 
     /**
      * Returns true if a given string is a valid faculty.
-     * @param test
-     * @return true if a given string is valid, false otherwise.
+     *
+     * @param test string to be tested to determine if valid faculty.
+     * @return Boolean result where it is true if a given string is a valid faculty, false otherwise.
      */
     public static boolean isValidFaculty(String test) {
         return Stream.of(Nus.values())

--- a/src/main/java/seedu/address/model/person/MatriculationNumber.java
+++ b/src/main/java/seedu/address/model/person/MatriculationNumber.java
@@ -36,6 +36,9 @@ public class MatriculationNumber {
 
     /**
      * Returns true if a given string is a valid matriculation number.
+     *
+     * @param test string to be tested to determine if valid matriculation number.
+     * @return Boolean result where it is true if a given string is a valid number, false otherwise.
      */
     public static boolean isValidMatriculationNumber(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -33,6 +33,9 @@ public class Name {
 
     /**
      * Returns true if a given string is a valid name.
+     *
+     * @param test string to be tested to determine if valid name.
+     * @return Boolean result where it is true if a given string is a valid name, false otherwise.
      */
     public static boolean isValidName(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -28,6 +28,9 @@ public class Phone {
 
     /**
      * Returns true if a given string is a valid phone number.
+     *
+     * @param test string to be tested to determine if valid Phone.
+     * @return Boolean result where it is true if a given string is a valid phone, false otherwise.
      */
     public static boolean isValidPhone(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -25,7 +25,7 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Block("A"), new Faculty("SOC"), new Phone("87438807"),
                     new Email("alexyeoh@example.com"), new Address("Blk 30 Geylang Street 29, #06-40"),
-                    new MatriculationNumber("a1234567m"), new CovidStatus("hrw"), getTagSet("friends")),
+                    new MatriculationNumber("a1234567m"), new CovidStatus("hrn"), getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Block("A"), new Faculty("FOS"), new Phone("99272758"),
                     new Email("berniceyu@example.com"), new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                     new MatriculationNumber("a7364736m"), new CovidStatus("negative"),
@@ -38,7 +38,7 @@ public class SampleDataUtil {
                     new MatriculationNumber("a1234423m"), new CovidStatus("negative"), getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Block("D"), new Faculty("FASS"), new Phone("92492021"),
                     new Email("irfan@example.com"), new Address("Blk 47 Tampines Street 20, #17-35"),
-                    new MatriculationNumber("a6374567m"), new CovidStatus("hrw"),
+                    new MatriculationNumber("a6374567m"), new CovidStatus("hrn"),
                     getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Block("E"), new Faculty("BIZ"), new Phone("92624417"),
                     new Email("royb@example.com"), new Address("Blk 45 Aljunied Street 85, #11-31"),

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -18,7 +18,7 @@
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
     "number" : "A1234567X",
-    "status" : "HRW",
+    "status" : "HRN",
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -48,7 +48,7 @@
     "email" : "werner@example.com",
     "address" : "michegan ave",
     "number" : "A4345678N",
-    "status" : "HRW",
+    "status" : "HRN",
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -45,7 +45,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_MATRICULATION_NUMBER_AMY = "A1234567A";
     public static final String VALID_MATRICULATION_NUMBER_BOB = "A2180000A";
-    public static final String VALID_COVID_STATUS_AMY = "HRW";
+    public static final String VALID_COVID_STATUS_AMY = "HRN";
     public static final String VALID_COVID_STATUS_BOB = "POSITIVE";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -30,14 +30,12 @@ public class FilterCommandTest {
 
     private CovidStatus positive = new CovidStatus("positive");
     private CovidStatus negative = new CovidStatus("negative");
-    private CovidStatus hrw = new CovidStatus("hrw");
     private CovidStatus hrn = new CovidStatus("hrn");
 
     @Test
     public void isStatus_correctOutput() {
         // correctly matches CovidStatus input -> returns true
         assertTrue(CARL.isStatus(hrn));
-        assertTrue(ELLE.isStatus(hrw));
         assertTrue(FIONA.isStatus(negative));
         assertTrue(GEORGE.isStatus(positive));
 
@@ -50,7 +48,7 @@ public class FilterCommandTest {
     public void equals() {
 
         FilterCommand filterFirstCommand = new FilterCommand("positive");
-        FilterCommand filterSecondCommand = new FilterCommand("hrw");
+        FilterCommand filterSecondCommand = new FilterCommand("negative");
 
         // same object -> returns true
         assertTrue(filterFirstCommand.equals(filterFirstCommand));

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -6,6 +6,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains unit tests for Address class and its methods.
+ */
 public class AddressTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/BlockTest.java
+++ b/src/test/java/seedu/address/model/person/BlockTest.java
@@ -9,6 +9,9 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains unit tests for Block class and its methods.
+ */
 public class BlockTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/BlockTest.java
+++ b/src/test/java/seedu/address/model/person/BlockTest.java
@@ -1,0 +1,48 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class BlockTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Block(null));
+    }
+
+    @Test
+    public void constructor_invalidBlock_throwsIllegalArgumentException() {
+        String invalidBlock = "";
+        assertThrows(IllegalArgumentException.class, () -> new Block(invalidBlock));
+    }
+
+    @Test
+    public void isValidBlock() {
+        //null faculty
+        assertFalse(Block.isValidBlock(null));
+
+        //invalid faculty
+        assertFalse(Block.isValidBlock("")); // empty string
+        assertFalse(Block.isValidBlock(" ")); // spaces only
+        assertFalse(Block.isValidBlock("F")); // incorrect status
+        assertFalse(Block.isValidBlock("1")); // incorrect status
+
+        //Valid faculty
+        assertTrue(Block.isValidBlock("a")); // lowercase, correct status
+        assertTrue(Block.isValidBlock("A")); // correct status
+    }
+
+    @Test
+    public void getBlockEnumAsString() {
+        String listOfBlock = "A B C D E ";
+        StringBuilder stringBuilder = new StringBuilder();
+        Stream.of(Block.HallBlock.values()).forEach(block -> stringBuilder.append(block + " "));
+        assertEquals(listOfBlock, stringBuilder.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/CovidStatusTest.java
+++ b/src/test/java/seedu/address/model/person/CovidStatusTest.java
@@ -9,6 +9,9 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains unit tests for CovidStatus class and its methods.
+ */
 public class CovidStatusTest {
 
     @Test
@@ -24,15 +27,15 @@ public class CovidStatusTest {
 
     @Test
     public void isValidCovidStatus() {
-        //null faculty
+        //null status
         assertFalse(CovidStatus.isValidCovidStatus(null));
 
-        //invalid faculty
+        //invalid status
         assertFalse(CovidStatus.isValidCovidStatus("")); // empty string
         assertFalse(CovidStatus.isValidCovidStatus(" ")); // spaces only
         assertFalse(CovidStatus.isValidCovidStatus("HRW")); // incorrect status
 
-        //Valid faculty
+        //Valid status
         assertTrue(CovidStatus.isValidCovidStatus("hrn")); // all lowercase, correct status
         assertTrue(CovidStatus.isValidCovidStatus("POSITIVE")); // correct status
     }

--- a/src/test/java/seedu/address/model/person/CovidStatusTest.java
+++ b/src/test/java/seedu/address/model/person/CovidStatusTest.java
@@ -1,0 +1,47 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class CovidStatusTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new CovidStatus(null));
+    }
+
+    @Test
+    public void constructor_invalidCovidStatus_throwsIllegalArgumentException() {
+        String invalidCovidStatus = "";
+        assertThrows(IllegalArgumentException.class, () -> new CovidStatus(invalidCovidStatus));
+    }
+
+    @Test
+    public void isValidCovidStatus() {
+        //null faculty
+        assertFalse(CovidStatus.isValidCovidStatus(null));
+
+        //invalid faculty
+        assertFalse(CovidStatus.isValidCovidStatus("")); // empty string
+        assertFalse(CovidStatus.isValidCovidStatus(" ")); // spaces only
+        assertFalse(CovidStatus.isValidCovidStatus("HRW")); // incorrect status
+
+        //Valid faculty
+        assertTrue(CovidStatus.isValidCovidStatus("hrn")); // all lowercase, correct status
+        assertTrue(CovidStatus.isValidCovidStatus("POSITIVE")); // correct status
+    }
+
+    @Test
+    public void getCovidStatusEnumAsString() {
+        String listOfCovidStatus = "HRN NEGATIVE POSITIVE ";
+        StringBuilder stringBuilder = new StringBuilder();
+        Stream.of(CovidStatus.CovidStatusTier.values()).forEach(status -> stringBuilder.append(status + " "));
+        assertEquals(listOfCovidStatus, stringBuilder.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -6,6 +6,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains unit tests for Email class and its methods.
+ */
 public class EmailTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/FacultyTest.java
+++ b/src/test/java/seedu/address/model/person/FacultyTest.java
@@ -9,6 +9,9 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains unit tests for Faculty class and its methods.
+ */
 public class FacultyTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/FacultyTest.java
+++ b/src/test/java/seedu/address/model/person/FacultyTest.java
@@ -1,0 +1,48 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+public class FacultyTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Faculty(null));
+    }
+
+    @Test
+    public void constructor_invalidFaculty_throwsIllegalArgumentException() {
+        String invalidFaculty = "";
+        assertThrows(IllegalArgumentException.class, () -> new Faculty(invalidFaculty));
+    }
+
+    @Test
+    public void isValidFaculty() {
+        //null faculty
+        assertFalse(Faculty.isValidFaculty(null));
+
+        //invalid faculty
+        assertFalse(Faculty.isValidFaculty("")); // empty string
+        assertFalse(Faculty.isValidFaculty(" ")); // spaces only
+        assertFalse(Faculty.isValidFaculty("SOOC")); // incorrect faculty
+
+        //Valid faculty
+        assertTrue(Faculty.isValidFaculty("soc")); // all lowercase, correct faculty
+        assertTrue(Faculty.isValidFaculty("SoC")); // correct faculty
+        assertTrue(Faculty.isValidFaculty("SOC")); // all uppercase, correct faculty
+    }
+
+    @Test
+    public void getFacultyEnumAsString() {
+        String listOfFaculties = "FASS BIZ SOC SCALE FOD CDE DUKE FOL YLLSOM YSTCOM SOPP LKYSPP SPH TEST FOS ";
+        StringBuilder stringBuilder = new StringBuilder();
+        Stream.of(Faculty.Nus.values()).forEach(faculty -> stringBuilder.append(faculty + " "));
+        assertEquals(listOfFaculties, stringBuilder.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/MatriculationNumberTest.java
+++ b/src/test/java/seedu/address/model/person/MatriculationNumberTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains unit tests for MatriculationNumber class and its methods.
+ */
 public class MatriculationNumberTest {
 
     @Test
@@ -30,6 +33,8 @@ public class MatriculationNumberTest {
         assertFalse(MatriculationNumber.isValidMatriculationNumber("A123456D")); // 6 numbers
         assertFalse(MatriculationNumber.isValidMatriculationNumber("A12345678")); // 8 numbers
         assertFalse(MatriculationNumber.isValidMatriculationNumber("A12345678$")); // format is of AXXXXXXX{Alpha}
+        assertFalse(MatriculationNumber.isValidMatriculationNumber("B12345678G")); // first character
+        // should be an a/A
 
         // valid matriculation number
         assertTrue(MatriculationNumber.isValidMatriculationNumber("a1234567g")); // all lowercase, correct number

--- a/src/test/java/seedu/address/model/person/MatriculationNumberTest.java
+++ b/src/test/java/seedu/address/model/person/MatriculationNumberTest.java
@@ -1,0 +1,42 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class MatriculationNumberTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new MatriculationNumber(null));
+    }
+
+    @Test
+    public void constructor_invalidMatriculationNumber_throwsIllegalArgumentException() {
+        String invalidMatriculationNumber = "";
+        assertThrows(IllegalArgumentException.class, () -> new MatriculationNumber(invalidMatriculationNumber));
+    }
+
+    @Test
+    public void isValidMatriculationNumber() {
+        // null matriculation number
+        assertThrows(NullPointerException.class, () -> MatriculationNumber.isValidMatriculationNumber(null));
+
+        // invalid matriculation number
+        assertFalse(MatriculationNumber.isValidMatriculationNumber("")); // empty string
+        assertFalse(MatriculationNumber.isValidMatriculationNumber(" ")); // spaces only
+        assertFalse(MatriculationNumber.isValidMatriculationNumber("A123456D")); // 6 numbers
+        assertFalse(MatriculationNumber.isValidMatriculationNumber("A12345678")); // 8 numbers
+        assertFalse(MatriculationNumber.isValidMatriculationNumber("A12345678$")); // format is of AXXXXXXX{Alpha}
+
+        // valid matriculation number
+        assertTrue(MatriculationNumber.isValidMatriculationNumber("a1234567g")); // all lowercase, correct number
+        assertTrue(MatriculationNumber.isValidMatriculationNumber("A0000000H")); // all uppercase, correct number
+        assertTrue(MatriculationNumber.isValidMatriculationNumber("A0000000d")); // all uppercase,
+        // lowercase alphanumeric, correct number
+        assertTrue(MatriculationNumber.isValidMatriculationNumber("a0000000D")); // all uppercase,
+        // lowercase first character, correct number
+    }
+}

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
 
+/**
+ * Contains unit tests for NameContainsKeywordsPredicate class and its methods.
+ */
 public class NameContainsKeywordsPredicateTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -6,6 +6,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains unit tests for Name class and its methods.
+ */
 public class NameTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -15,6 +15,9 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
 
+/**
+ * Contains unit tests for Person class and its methods.
+ */
 public class PersonTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -6,6 +6,9 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Contains unit tests for Phone class and its methods.
+ */
 public class PhoneTest {
 
     @Test

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -19,6 +19,9 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.testutil.PersonBuilder;
 
+/**
+ * Contains unit tests for UniquePersonList class and its methods.
+ */
 public class UniquePersonListTest {
 
     private final UniquePersonList uniquePersonList = new UniquePersonList();

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -47,7 +47,7 @@ public class TypicalPersons {
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withMatricNumber("A1234567X")
-            .withCovidStatus("HRW")
+            .withCovidStatus("HRN")
             .withTags("owesMoney", "friends")
             .build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz")
@@ -76,7 +76,7 @@ public class TypicalPersons {
             .withEmail("werner@example.com")
             .withAddress("michegan ave")
             .withMatricNumber("A4345678N")
-            .withCovidStatus("HRW")
+            .withCovidStatus("HRN")
             .build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz")
             .withBlock("B")


### PR DESCRIPTION
Previously, new attributes(Block, Faculty, Matriculation Number and Covid Status) were added to fulfill our application's problem domain of Covid Status tracking. This is a continuation to these additions by providing test cases for unit testing.

Additionally, this PR also removed the HRW enum value from CovidStatusTier in CovidStatus.java. Consequently, SummariseCommand.java, FilterCommandTest.java, addressbooks and sample data files needed to be altered to accommodate this change by removing the "HRW" dependency

As mentioned, this PR is related to https://github.com/AY2122S2-CS2103T-T12-3/tp/pull/33 and is dependent on https://github.com/AY2122S2-CS2103T-T12-3/tp/pull/62 where the block attribute is added.

This PR should be merged after https://github.com/AY2122S2-CS2103T-T12-3/tp/pull/62 due to the dependencies on the block class.

These test cases allows Faculty.java, MatriculationNumber.java, Block.java and CovidStatus.java to achieve >=80% method coverage and >=90% line coverage