### PR TITLE
add EmailWindow button and window to copy email

### DIFF
--- a/src/main/java/seedu/address/ui/ActionBar.java
+++ b/src/main/java/seedu/address/ui/ActionBar.java
@@ -1,0 +1,14 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.layout.Region;
+
+public class ActionBar extends UiPart<Region> {
+
+    private static final String FXML = "ActionBar.fxml";
+
+    public ActionBar() {
+        super(FXML);
+    }
+
+}

--- a/src/main/java/seedu/address/ui/EmailWindow.java
+++ b/src/main/java/seedu/address/ui/EmailWindow.java
@@ -53,12 +53,12 @@ public class EmailWindow extends UiPart<Stage> {
      * @param personList list of Person objects currently in the PersonList.
      */
     public String parseEmailFromList(ObservableList<Person> personList) {
-        String stringOfEmail = "";
+        String stringOfEmails = "";
         for (Person p : personList) {
             Email personEmail = p.getEmail();
-            stringOfEmail = stringOfEmail + personEmail.toString() + "\n";
+            stringOfEmails = stringOfEmails + personEmail.toString() + "\n";
         }
-        return stringOfEmail;
+        return stringOfEmails;
     }
 
     /**
@@ -112,9 +112,9 @@ public class EmailWindow extends UiPart<Stage> {
     @FXML
     private void copyEmail() {
         final Clipboard clipboard = Clipboard.getSystemClipboard();
-        final ClipboardContent email = new ClipboardContent();
-        email.putString(emailStringForCopy);
-        clipboard.setContent(email);
+        final ClipboardContent copyEmail = new ClipboardContent();
+        copyEmail.putString(emailStringForCopy);
+        clipboard.setContent(copyEmail);
     }
 
 }

--- a/src/main/java/seedu/address/ui/EmailWindow.java
+++ b/src/main/java/seedu/address/ui/EmailWindow.java
@@ -1,0 +1,120 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
+import javafx.stage.Stage;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Person;
+
+
+public class EmailWindow extends UiPart<Stage> {
+
+    private static final Logger logger = LogsCenter.getLogger(EmailWindow.class);
+    private static final String FXML = "EmailWindow.fxml";
+    private String emailStringForCopy;
+
+    @FXML
+    private Button copyButton;
+
+    @FXML
+    private Label emailList;
+
+    /**
+     * Creates a new EmailWindow.
+     *
+     * @param root Stage to use as the root of the EmailWindow.
+     */
+    public EmailWindow(Stage root) {
+        super(FXML, root);
+    }
+
+    /**
+     * Creates a new EmailWindow.
+     *
+     * @param personList list of Person objects currently in the PersonList.
+     */
+    public EmailWindow(ObservableList<Person> personList) {
+        this(new Stage());
+        String emailString = parseEmailFromList(personList);
+        emailList.setText(emailString);
+        this.emailStringForCopy = emailString;
+    }
+
+    /**
+     * Iterate through the list of persons to obtain the email string of each Person.
+     *
+     * @param personList list of Person objects currently in the PersonList.
+     */
+    public String parseEmailFromList(ObservableList<Person> personList) {
+        String stringOfEmail = "";
+        for (Person p : personList) {
+            Email personEmail = p.getEmail();
+            stringOfEmail = stringOfEmail + personEmail.toString() + "\n";
+        }
+        return stringOfEmail;
+    }
+
+    /**
+     * Shows the email window.
+     * @throws IllegalStateException
+     * <ul>
+     *     <li>
+     *         if this method is called on a thread other than the JavaFX Application Thread.
+     *     </li>
+     *     <li>
+     *         if this method is called during animation or layout processing.
+     *     </li>
+     *     <li>
+     *         if this method is called on the primary stage.
+     *     </li>
+     *     <li>
+     *         if {@code dialogStage} is already showing.
+     *     </li>
+     * </ul>
+     */
+    public void show() {
+        logger.fine("Showing email list page.");
+        getRoot().show();
+        getRoot().centerOnScreen();
+    }
+
+    /**
+     * Returns true if the email window is currently being shown.
+     */
+    public boolean isShowing() {
+        return getRoot().isShowing();
+    }
+
+    /**
+     * Hides the email window.
+     */
+    public void hide() {
+        getRoot().hide();
+    }
+
+    /**
+     * Focuses on the email window.
+     */
+    public void focus() {
+        getRoot().requestFocus();
+    }
+
+    /**
+     * Copies the emails in the string of emails to the clipboard.
+     */
+    @FXML
+    private void copyEmail() {
+        final Clipboard clipboard = Clipboard.getSystemClipboard();
+        final ClipboardContent email = new ClipboardContent();
+        email.putString(emailStringForCopy);
+        clipboard.setContent(email);
+    }
+
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -33,6 +33,7 @@ public class MainWindow extends UiPart<Stage> {
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
+    private EmailWindow emailWindow;
     private HelpWindow helpWindow;
 
     @FXML
@@ -120,7 +121,6 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
@@ -152,6 +152,31 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    /**
+     * Opens the email window or opens an updated window it if it's already opened.
+     */
+    @FXML
+    public void handleEmailWindow() {
+        if (emailWindow == null) {
+            createEmailWindow();
+        }
+
+        if (!emailWindow.isShowing()) {
+            createEmailWindow();
+        } else {
+            emailWindow.hide();
+            createEmailWindow();
+        }
+    }
+
+    /**
+     * Instantiates an EmailWindow and shows it.
+     */
+    public void createEmailWindow() {
+        emailWindow = new EmailWindow(logic.getFilteredPersonList());
+        emailWindow.show();
+    }
+
     void show() {
         primaryStage.show();
     }
@@ -165,6 +190,7 @@ public class MainWindow extends UiPart<Stage> {
                 (int) primaryStage.getX(), (int) primaryStage.getY());
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
+        emailWindow.hide();
         primaryStage.hide();
     }
 

--- a/src/main/resources/view/EmailWindow.css
+++ b/src/main/resources/view/EmailWindow.css
@@ -1,0 +1,19 @@
+#emailButton, #helpMessage {
+    -fx-text-fill: white;
+}
+
+#emailButton {
+    -fx-background-color: dimgray;
+}
+
+#emailButton:hover {
+    -fx-background-color: gray;
+}
+
+#emailButton:armed {
+    -fx-background-color: darkgray;
+}
+
+#emailMessageContainer {
+    -fx-background-color: derive(#1d1d1d, 20%);
+}

--- a/src/main/resources/view/EmailWindow.fxml
+++ b/src/main/resources/view/EmailWindow.fxml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Scene?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.stage.Stage?>
+
+<fx:root resizable="false" title="Email List" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <icons>
+        <Image url="@/images/info_icon.png" />
+    </icons>
+    <scene>
+        <Scene>
+            <stylesheets>
+                <URL value="@EmailWindow.css" />
+            </stylesheets>
+
+            <HBox fx:id="emailMessageContainer" alignment="CENTER">
+                <children>
+                    <Label fx:id="emailList" text="Label" textFill="WHITE" prefWidth="300">
+                        <HBox.margin>
+                            <Insets right="5.0" />
+                        </HBox.margin>
+                    </Label>
+                    <Button fx:id="emailButton" mnemonicParsing="false" onAction="#copyEmail" text="Copy Email">
+                        <HBox.margin>
+                            <Insets left="5.0" />
+                        </HBox.margin>
+                    </Button>
+                </children>
+                <opaqueInsets>
+                    <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+                </opaqueInsets>
+                <padding>
+                    <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+                </padding>
+            </HBox>
+        </Scene>
+    </scene>
+</fx:root>

--- a/src/main/resources/view/MainWindow.css
+++ b/src/main/resources/view/MainWindow.css
@@ -1,0 +1,15 @@
+#emailButton {
+    -fx-text-fill: white;
+}
+
+#emailButton {
+    -fx-background-color: dimgray;
+}
+
+#emailButton {
+    -fx-border-radius: 5px;
+}
+
+#emailButton:hover {
+    -fx-background-color: gray;
+}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -6,13 +6,13 @@
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.stage.Stage?>
 
-<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+<?import javafx.scene.control.Button?>
+<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Address App" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -21,6 +21,7 @@
       <stylesheets>
         <URL value="@DarkTheme.css" />
         <URL value="@Extensions.css" />
+        <URL value="@MainWindow.css" />
       </stylesheets>
 
       <VBox>
@@ -33,24 +34,32 @@
           </Menu>
         </MenuBar>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+        <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
           <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
+            <Insets bottom="5" left="10" right="10" top="5" />
           </padding>
         </StackPane>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+        <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100" styleClass="pane-with-border" VBox.vgrow="NEVER">
           <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
+            <Insets bottom="5" left="10" right="10" top="5" />
           </padding>
         </StackPane>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+        <StackPane fx:id="actionBarPlaceholder" maxHeight="35" minHeight="35" prefHeight="35" styleClass="pane-with-border" VBox.vgrow="NEVER">
           <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
+            <Insets bottom="5" left="10" right="10" top="5" />
           </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <Button fx:id="emailButton" onAction="#handleEmailWindow" text="Show Email" StackPane.alignment="CENTER_RIGHT" >
+          </Button>
+
+        </StackPane>
+
+        <VBox fx:id="personList" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+          <padding>
+            <Insets bottom="10" left="10" right="10" top="10" />
+          </padding>
+          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
         </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />


### PR DESCRIPTION
<img width="732" alt="Screenshot 2022-03-22 at 6 33 20 PM" src="https://user-images.githubusercontent.com/51451719/159462644-79f61c99-96cf-4da3-a5ed-0e12040377dd.png">

This PR is intended to address the User Story where the admin can retrieve a list of student emails for easy copy-pasting into an email domain. This PR involves addition of an EmailWindow class and altering the MainWindow class and its FXML files. When the Show Email button is pressed, if the EmailWindow object does not exists, it instantiates a new EmailWindow object. If not, the application will close the current EmailWindow object and open a new one to retrieve an updatedlist. The copy function utilises the Clipboard class to copy the text of emails into the User's operating system's clipboard.

The purpose of this PR is to get feedback for the initial implementation and request for comment.

It is part of a greater set of changes and is not dependent on any concurrent PR.

Things to consider: 
With the addition of the new stackpane, filter tabs can be placed in the same pane to display to the user what their search requests is currently filtered by.