### PR TITLE
Update function of help window button to open UG

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -170,7 +170,7 @@ public class HelpWindow extends UiPart<Stage> {
                 e.printStackTrace();
             }
         } else {
-            logger.info("User operating system not supported");
+            logger.warning("User operating system not supported");
             Alert alert = new Alert(Alert.AlertType.ERROR, "Your operating system is currently not supported!");
             alert.show();
         }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -169,6 +169,9 @@ public class HelpWindow extends UiPart<Stage> {
                 alert.show();
                 e.printStackTrace();
             }
+        } else {
+            Alert alert = new Alert(Alert.AlertType.ERROR, "Your operating system is currently not supported!");
+            alert.show();
         }
     }
 }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -1,12 +1,14 @@
 package seedu.address.ui;
 
+import java.awt.Desktop;
+import java.io.IOException;
+import java.net.URI;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.input.Clipboard;
-import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
@@ -152,14 +154,18 @@ public class HelpWindow extends UiPart<Stage> {
         getRoot().requestFocus();
     }
 
-    /**
-     * Copies the URL to the user guide to the clipboard.
-     */
+
     @FXML
-    private void copyUrl() {
-        final Clipboard clipboard = Clipboard.getSystemClipboard();
-        final ClipboardContent url = new ClipboardContent();
-        url.putString(USERGUIDE_URL);
-        clipboard.setContent(url);
+    private void openUG() {
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            try {
+                Desktop desktop = Desktop.getDesktop();
+                desktop.browse(URI.create(USERGUIDE_URL));
+            } catch (IOException e) {
+                Alert alert = new Alert(Alert.AlertType.ERROR, "The URL is currently down/being changed!");
+                alert.show();
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -155,6 +155,9 @@ public class HelpWindow extends UiPart<Stage> {
     }
 
 
+    /**
+     * Open the User Guide in the User's default browser.
+     */
     @FXML
     private void openUG() {
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -87,7 +87,7 @@ public class HelpWindow extends UiPart<Stage> {
 
 
     @FXML
-    private Button copyButton;
+    private Button openUserGuideButton;
 
     @FXML
     private Label helpMessage;

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -170,6 +170,7 @@ public class HelpWindow extends UiPart<Stage> {
                 e.printStackTrace();
             }
         } else {
+            logger.info("User operating system not supported");
             Alert alert = new Alert(Alert.AlertType.ERROR, "Your operating system is currently not supported!");
             alert.show();
         }

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -26,7 +26,7 @@
               <Insets right="5.0" />
             </HBox.margin>
           </Label>
-          <Button fx:id="copyButton" mnemonicParsing="false" onAction="#openUG" text="Open User Guide">
+          <Button fx:id="openUserGuideButton" mnemonicParsing="false" onAction="#openUG" text="Open User Guide">
             <HBox.margin>
               <Insets left="5.0" />
             </HBox.margin>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -26,7 +26,7 @@
               <Insets right="5.0" />
             </HBox.margin>
           </Label>
-          <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy UG URL">
+          <Button fx:id="copyButton" mnemonicParsing="false" onAction="#openUG" text="Open User Guide">
             <HBox.margin>
               <Insets left="5.0" />
             </HBox.margin>


### PR DESCRIPTION
![Screenshot 2022-03-28 at 2 24 22 AM](https://user-images.githubusercontent.com/51451719/160295219-1d4315a7-0cff-43c0-9353-b41c991e602e.png)
This PR aims to update the functionality of the button in the HelpWindow window. Previously, the button simply copied the UserGuide URL to the user's clipboard. With this PR, the browser will navigate to our group's user guide through the User's default browser.

This is done through utilising the awt.Desktop library and creating a desktop instance to access the instantiated URI.

This PR serves as an initial implementation and is open to feedback from my teammates.

This PR is not dependent on any other PRs.