### PR TITLE
Add on to AddressBookParserTest

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SummariseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummariseCommand.java
@@ -165,7 +165,7 @@ public class SummariseCommand extends Command {
      * @param list the unfiltered entire list in the database
      * @return The summarised overview for all students
      */
-    public String summariseAll(List<Person> list) {
+    private String summariseAll(List<Person> list) {
         StringBuilder ans = new StringBuilder();
         int numberOfStudents = list.size();
 

--- a/src/main/java/seedu/address/logic/commands/SummariseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummariseCommand.java
@@ -77,7 +77,7 @@ public class SummariseCommand extends Command {
     /**
      * Filter entire list by faculties to provide overview of covid situation in each faculty.
      *
-     * @param list the unfiltered entire list in the database
+     * @param list a list of all students found within the address book
      * @return The summarised overview for all students by faculties
      */
     public String filterByFaculty(List<Person> list) {
@@ -99,7 +99,7 @@ public class SummariseCommand extends Command {
     /**
      * Filter entire list by the hall block to provide overview of covid situation in each block.
      *
-     * @param list the unfiltered entire list in the database
+     * @param list a list of all students found within the address book
      * @return The summarised overview for all students by blocks
      */
     public String filterByBlock(List<Person> list) {
@@ -162,7 +162,7 @@ public class SummariseCommand extends Command {
     /**
      * Filter entire list to provide overview of covid situation in the hall.
      *
-     * @param list the unfiltered entire list in the database
+     * @param list a list of all students found within the address book
      * @return The summarised overview for all students
      */
     private String summariseAll(List<Person> list) {

--- a/src/test/java/seedu/address/logic/commands/SummariseCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SummariseCommandTest.java
@@ -58,4 +58,17 @@ public class SummariseCommandTest {
         assertTrue(actual.length() > 0);
     }
 
+    @Test
+    public void filterByBlock_onEmptyList_showsEmptyString() {
+        List<Person> emptyList = new ArrayList<>();
+        String actual = new SummariseCommand().filterByBlock(emptyList);
+        assertEquals(actual, "");
+    }
+
+    @Test
+    public void filterByBlock_onValidList_showsNonEmptyString() {
+        List<Person> validList = model.getFilteredPersonList();
+        String actual = new SummariseCommand().filterByBlock(validList);
+        assertTrue(actual.length() > 0);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -110,9 +110,9 @@ public class AddressBookParserTest {
     public void parseCommand_filter() throws Exception {
         FilterCommand.FilterDescriptor filterDescriptorTest = new FilterCommand.FilterDescriptor();
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FilterCommand command2 = (FilterCommand) parser.parseCommand(
+        FilterCommand command = (FilterCommand) parser.parseCommand(
                 FilterCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FilterCommand(filterDescriptorTest), command2);
+        assertEquals(new FilterCommand(filterDescriptorTest), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -19,9 +19,11 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SummariseCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -86,6 +88,21 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_summarise() throws Exception {
+        assertTrue(parser.parseCommand(SummariseCommand.COMMAND_WORD) instanceof SummariseCommand);
+        assertTrue(parser.parseCommand(SummariseCommand.COMMAND_WORD + " 3") instanceof SummariseCommand);
+    }
+
+    @Test
+    public void parseCommand_filter() throws Exception {
+        FilterCommand.FilterDescriptor filterDescriptorTest = new FilterCommand.FilterDescriptor();
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FilterCommand command2 = (FilterCommand) parser.parseCommand(
+                FilterCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FilterCommand(filterDescriptorTest), command2);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -32,6 +32,9 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
 
+/**
+ * Contains helper methods for testing address book parsers.
+ */
 public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -94,6 +95,12 @@ public class AddressBookParserTest {
     public void parseCommand_summarise() throws Exception {
         assertTrue(parser.parseCommand(SummariseCommand.COMMAND_WORD) instanceof SummariseCommand);
         assertTrue(parser.parseCommand(SummariseCommand.COMMAND_WORD + " 3") instanceof SummariseCommand);
+    }
+
+    @Test
+    public void parseCommand_archive() throws Exception {
+        assertTrue(parser.parseCommand(ArchiveCommand.COMMAND_WORD) instanceof ArchiveCommand);
+        assertTrue(parser.parseCommand(ArchiveCommand.COMMAND_WORD + " 3") instanceof ArchiveCommand);
     }
 
     @Test


### PR DESCRIPTION
Add test methods for filter and summarise for AddressBookParserTest as they were missing prior to this PR. This is a set of  more tests to all methods and classes to ensure code coverage of the files increase. 