### PR TITLE
Add undo feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -66,6 +66,7 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        model.saveHistory();
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -66,7 +66,6 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.saveHistory();
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -40,7 +40,6 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.saveHistory();
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -40,6 +40,7 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.saveHistory();
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -94,6 +94,7 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        model.saveHistory();
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -94,7 +94,6 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.saveHistory();
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Deletes a person identified using it's displayed index from the address book.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Erases the previous change to the address book and restores the the older state.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_UNDO_SUCCESS = "Undid last change.";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.restoreHistory();
+        return new CommandResult(MESSAGE_UNDO_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UndoCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -17,10 +17,16 @@ public class UndoCommand extends Command {
             + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_UNDO_SUCCESS = "Undid last change.";
+    public static final String MESSAGE_UNDO_FAILURE = "No previous changes.";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.checkHistory() == false) {
+            throw new CommandException(MESSAGE_UNDO_FAILURE);
+        }
+
         model.restoreHistory();
         return new CommandResult(MESSAGE_UNDO_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SummariseCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case ArchiveCommand.COMMAND_WORD:
             return new ArchiveCommand();
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -16,6 +16,8 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
 
+    private final UniquePersonList personsHistory;
+
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
      * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
@@ -25,6 +27,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
+        personsHistory = new UniquePersonList();
     }
 
     public AddressBook() {}
@@ -91,6 +94,20 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+    }
+
+    /**
+     * Saves the current list of persons in the address book.
+     */
+    public void saveHistory() {
+        this.personsHistory.setPersons(this.persons);
+    }
+
+    /**
+     * Restores the previous list of persons in the address book.
+     */
+    public void restoreHistory() {
+        this.persons.setPersons(this.personsHistory);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -15,7 +15,6 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
-
     private final UniquePersonList personsHistory;
 
     /*

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -15,7 +15,8 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
-    private final UniquePersonList personsHistory;
+
+    private UniquePersonList personsHistory;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -26,7 +27,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
-        personsHistory = new UniquePersonList();
+        personsHistory = null;
     }
 
     public AddressBook() {}
@@ -99,6 +100,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Saves the current list of persons in the address book.
      */
     public void saveHistory() {
+        if (this.personsHistory == null) {
+            this.personsHistory = new UniquePersonList();
+        }
         this.personsHistory.setPersons(this.persons);
     }
 
@@ -107,6 +111,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void restoreHistory() {
         this.persons.setPersons(this.personsHistory);
+    }
+
+    /**
+     * Retrieves the previous list of persons in the address book.
+     */
+    public UniquePersonList getHistory() {
+        return this.personsHistory;
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -76,6 +76,16 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Saves the current state of the address book.
+     */
+    void saveHistory();
+
+    /**
+     * Restores the previous state of the address book.
+     */
+    void restoreHistory();
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -77,14 +77,14 @@ public interface Model {
     void setPerson(Person target, Person editedPerson);
 
     /**
-     * Saves the current state of the address book.
-     */
-    void saveHistory();
-
-    /**
      * Restores the previous state of the address book.
      */
     void restoreHistory();
+
+    /**
+     * Checks the presence of a previous state of the address book.
+     */
+    boolean checkHistory();
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -111,6 +111,16 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    @Override
+    public void saveHistory() {
+        addressBook.saveHistory();
+    }
+
+    @Override
+    public void restoreHistory() {
+        addressBook.restoreHistory();
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -115,14 +115,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void saveHistory() {
-        addressBook.saveHistory();
-    }
-
-    @Override
     public void restoreHistory() {
         addressBook.restoreHistory();
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
+    public boolean checkHistory() {
+        return addressBook.getHistory() != null;
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -95,11 +95,13 @@ public class ModelManager implements Model {
 
     @Override
     public void deletePerson(Person target) {
+        addressBook.saveHistory();
         addressBook.removePerson(target);
     }
 
     @Override
     public void addPerson(Person person) {
+        addressBook.saveHistory();
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
@@ -108,6 +110,7 @@ public class ModelManager implements Model {
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 
+        addressBook.saveHistory();
         addressBook.setPerson(target, editedPerson);
     }
 
@@ -119,6 +122,7 @@ public class ModelManager implements Model {
     @Override
     public void restoreHistory() {
         addressBook.restoreHistory();
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -152,6 +152,14 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void saveHistory() {}
+
+        @Override
+        public void restoreHistory() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -154,10 +154,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public void saveHistory() {}
+        public void restoreHistory() {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
-        public void restoreHistory() {
+        public boolean checkHistory() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,0 +1,96 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalPersons;
+
+
+public class UndoCommandTest {
+
+    @Test
+    public void execute_undoForAddFunction_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        model.addPerson(TypicalPersons.HOON);
+
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_undoForDeleteFunction_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+        expectedModel.addPerson(TypicalPersons.ALICE);
+
+        model.deletePerson(TypicalPersons.ALICE);
+
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        model.addPerson(TypicalPersons.HOON);
+
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_undoForEditFunction_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+        expectedModel.addPerson(TypicalPersons.ALICE);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(firstPerson);
+        Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+
+        model.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        personInList = new PersonBuilder(firstPerson);
+        editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+
+        model.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_UNDO_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void test_undoCommandWordIsCorrect() {
+        assertTrue(UndoCommand.COMMAND_WORD.equals("undo"));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.UndoCommand.MESSAGE_UNDO_FAILURE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -21,6 +23,13 @@ import seedu.address.testutil.TypicalPersons;
  * Contains integration tests (interaction with the Model) for {@code UndoCommand}.
  */
 public class UndoCommandTest {
+
+    @Test
+    public void execute_undoAsFirstFunction_failure() {
+        Model model = new ModelManager();
+
+        assertCommandFailure(new UndoCommand(), model, MESSAGE_UNDO_FAILURE);
+    }
 
     @Test
     public void execute_undoForAddFunction_success() {

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -17,7 +17,9 @@ import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.TypicalPersons;
 
-
+/**
+ * Contains integration tests (interaction with the Model) for {@code UndoCommand}.
+ */
 public class UndoCommandTest {
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -98,8 +98,15 @@ public class TypicalPersons {
             .build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").build();
+    public static final Person HOON = new PersonBuilder().withName("Hoon Meier")
+            .withBlock("E")
+            .withFaculty("SOC")
+            .withPhone("8482424")
+            .withEmail("stefan@example.com")
+            .withAddress("little india")
+            .withMatriculationNumber("A0843245H")
+            .withCovidStatus("POSITIVE")
+            .build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withAddress("chicago ave").withMatriculationNumber("A5243627L").build();
 


### PR DESCRIPTION
Added undo feature to address Issue #106 

Undo feature undoes the previous executed Add, Delete or Edit command. Each of these commands will save the current version of the address book inside the AddressBook object before it is executed, and Undo Command will retrieve this saved version. 

Unit testing has been executed to ensure its success in undoing the above 3 commands. 