### PR TITLE
Add redo feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Reverses an executed Undo command.
+ */
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Erases the previous change by undo to the address book and restores the original state, "
+            + "only can be used after a undo command.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_REDO_SUCCESS = "Reverted to original.";
+    public static final String MESSAGE_REDO_FAILURE = "You have to use the undo command first.";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.checkOriginal() == false) {
+            throw new CommandException(MESSAGE_REDO_FAILURE);
+        }
+
+        model.restoreOriginal();
+        return new CommandResult(MESSAGE_REDO_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RedoCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -6,14 +6,14 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 /**
- * Deletes a person identified using it's displayed index from the address book.
+ * Undoes the previous command.
  */
 public class UndoCommand extends Command {
 
     public static final String COMMAND_WORD = "undo";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Erases the previous change to the address book and restores the the older state.\n"
+            + ": Erases the previous change to the address book and restores the older state.\n"
             + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_UNDO_SUCCESS = "Undid last change.";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SummariseCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -83,6 +84,9 @@ public class AddressBookParser {
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -18,6 +18,8 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     private UniquePersonList personsHistory;
 
+    private UniquePersonList personsOriginal;
+
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
      * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
@@ -28,6 +30,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     {
         persons = new UniquePersonList();
         personsHistory = null;
+        personsOriginal = null;
     }
 
     public AddressBook() {}
@@ -97,7 +100,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Saves the current list of persons in the address book.
+     * Saves the previous list of persons in the address book.
      */
     public void saveHistory() {
         if (this.personsHistory == null) {
@@ -118,6 +121,35 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public UniquePersonList getHistory() {
         return this.personsHistory;
+    }
+
+    /**
+     * Saves the original list of persons in the address book.
+     */
+    public void saveOriginal() {
+        this.personsOriginal = new UniquePersonList();
+        this.personsOriginal.setPersons(this.persons);
+    }
+
+    /**
+     * Restores the current list of person in the address book.
+     */
+    public void restoreOriginal() {
+        this.persons.setPersons(this.personsOriginal);
+    }
+
+    /**
+     * Retrieves the original list of persons in the address book.
+     */
+    public UniquePersonList getOriginal() {
+        return this.personsOriginal;
+    }
+
+    /**
+     * Resets personsOriginal to null.
+     */
+    public void resetOriginal() {
+        this.personsOriginal = null;
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -86,6 +86,17 @@ public interface Model {
      */
     boolean checkHistory();
 
+    /**
+     * Restores the original state of the address book.
+     */
+    void restoreOriginal();
+
+    /**
+     * Checks the presence of an original state of the address book.
+     * @return
+     */
+    boolean checkOriginal();
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -95,12 +95,14 @@ public class ModelManager implements Model {
 
     @Override
     public void deletePerson(Person target) {
+        addressBook.resetOriginal();
         addressBook.saveHistory();
         addressBook.removePerson(target);
     }
 
     @Override
     public void addPerson(Person person) {
+        addressBook.resetOriginal();
         addressBook.saveHistory();
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
@@ -110,12 +112,14 @@ public class ModelManager implements Model {
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 
+        addressBook.resetOriginal();
         addressBook.saveHistory();
         addressBook.setPerson(target, editedPerson);
     }
 
     @Override
     public void restoreHistory() {
+        addressBook.saveOriginal();
         addressBook.restoreHistory();
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
@@ -123,6 +127,17 @@ public class ModelManager implements Model {
     @Override
     public boolean checkHistory() {
         return addressBook.getHistory() != null;
+    }
+
+    @Override
+    public void restoreOriginal() {
+        addressBook.restoreOriginal();
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
+    public boolean checkOriginal() {
+        return addressBook.getOriginal() != null;
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -162,6 +162,16 @@ public class AddCommandTest {
         public boolean checkHistory() {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void restoreOriginal() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean checkOriginal() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -1,0 +1,183 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.RedoCommand.COMMAND_WORD;
+import static seedu.address.logic.commands.RedoCommand.MESSAGE_REDO_FAILURE;
+import static seedu.address.logic.commands.RedoCommand.MESSAGE_REDO_SUCCESS;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalPersons;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code RedoCommand}.
+ */
+public class RedoCommandTest {
+
+    @Test
+    public void execute_redoAsFirstFunction_failure() {
+        Model model = new ModelManager();
+
+        assertCommandFailure(new RedoCommand(), model, MESSAGE_REDO_FAILURE);
+    }
+
+    @Test
+    public void execute_redoAfterAddFunction_failure() {
+        Model model = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+
+        assertCommandFailure(new RedoCommand(), model, MESSAGE_REDO_FAILURE);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        model.addPerson(TypicalPersons.HOON);
+
+        assertCommandFailure(new RedoCommand(), model, MESSAGE_REDO_FAILURE);
+    }
+
+    @Test
+    public void execute_redoAfterDeleteFunction_failure() {
+        Model model = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+        model.deletePerson(TypicalPersons.ALICE);
+
+        assertCommandFailure(new RedoCommand(), model, MESSAGE_REDO_FAILURE);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        model.addPerson(TypicalPersons.HOON);
+        model.deletePerson(TypicalPersons.HOON);
+
+        assertCommandFailure(new RedoCommand(), model, MESSAGE_REDO_FAILURE);
+    }
+
+    @Test
+    public void execute_redoAfterEditFunction_failure() {
+        Model model = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(firstPerson);
+        Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+
+        model.setPerson(firstPerson, editedPerson);
+
+        assertCommandFailure(new RedoCommand(), model, MESSAGE_REDO_FAILURE);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        model.setPerson(firstPerson, editedPerson);
+
+        assertCommandFailure(new RedoCommand(), model, MESSAGE_REDO_FAILURE);
+    }
+
+    @Test
+    public void execute_redoForUndoAfterAddFunction_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+        model.restoreHistory();
+
+        expectedModel.addPerson(TypicalPersons.ALICE);
+
+        assertCommandSuccess(new RedoCommand(), model, MESSAGE_REDO_SUCCESS, expectedModel);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        model.addPerson(TypicalPersons.HOON);
+        model.restoreHistory();
+
+        expectedModel.addPerson(TypicalPersons.HOON);
+
+        assertCommandSuccess(new RedoCommand(), model, MESSAGE_REDO_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_redoForUndoAfterDeleteFunction_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+        model.deletePerson(TypicalPersons.ALICE);
+        model.restoreHistory();
+
+        assertCommandSuccess(new RedoCommand(), model, MESSAGE_REDO_SUCCESS, expectedModel);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        model.addPerson(TypicalPersons.HOON);
+        model.deletePerson(TypicalPersons.HOON);
+        model.restoreHistory();
+
+        assertCommandSuccess(new RedoCommand(), model, MESSAGE_REDO_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_redoForUndoAfterEditFunction_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        model.addPerson(TypicalPersons.ALICE);
+        expectedModel.addPerson(TypicalPersons.ALICE);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(firstPerson);
+        Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+
+        model.setPerson(firstPerson, editedPerson);
+        model.restoreHistory();
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(new RedoCommand(), model, MESSAGE_REDO_SUCCESS, expectedModel);
+
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        personInList = new PersonBuilder(firstPerson);
+        editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+
+        model.setPerson(firstPerson, editedPerson);
+        model.restoreHistory();
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(new RedoCommand(), model, MESSAGE_REDO_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void test_redoCommandWordIsCorrect() {
+        assertTrue(COMMAND_WORD.equals("redo"));
+    }
+
+    @Test
+    public void equals() {
+        RedoCommand command = new RedoCommand();
+        assertTrue(command.equals(new RedoCommand()));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -104,4 +104,10 @@ public class UndoCommandTest {
     public void test_undoCommandWordIsCorrect() {
         assertTrue(UndoCommand.COMMAND_WORD.equals("undo"));
     }
+
+    @Test
+    public void equals() {
+        UndoCommand command = new UndoCommand();
+        assertTrue(command.equals(new UndoCommand()));
+    }
 }


### PR DESCRIPTION
Redo command can only be used after an undo command to reverse its effects, as an extension to Undo feature #106 

Redo command makes use of an original state of the address book stored in AddressBook.java which will store the original state of the address book before an undo function is executed. This state will be used to replace the actual address book when the redo function is executed. 

Integration test cases have also been added. 