### PR TITLE
Change header from Tracey UG to UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Tracey User Guide
+title: User Guide
 ---
 
 # Tracey
@@ -76,7 +76,7 @@ Additional formatting guidelines:
 1. Ensure you have Java 11 or above installed in your Computer. <br>
  📓`Note:`
    1. If you are unsure of which version of Java you are on, follow these steps. Otherwise, continue on from step 2.
-   2. To check your java version: 
+   2. To check your java version:
       1. For Mac users, open up Terminal and type in `java --version`.
       2. For Windows users, open up Command Prompt and type in `java --version`.
    3. If you have the supported version of Java, the response should resemble something like this `java 11.0.9 2020-10-20 LTS`.


### PR DESCRIPTION
![Screenshot 2022-03-31 at 2 30 51 AM](https://user-images.githubusercontent.com/51451719/160906171-d15e7498-6fd4-4648-b139-169ea377a63d.png)
Previously the changing of the title caused the navbar to show "Tracey User Guide" which differs from the standard. 

This PR changes this back to User Guide to conform to the format of the webpage.