### PR TITLE
Refinements for summarise command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SummariseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummariseCommand.java
@@ -50,12 +50,14 @@ public class SummariseCommand extends Command {
     private static final Predicate<Person> BY_HRN = person -> person.getStatusAsString().equals("HRN");
     private static TreeMap<String, TreeMap<String, Integer>> covidStatsByBlockDataList;
     private static TreeMap<String, Integer> positiveStatsByFacultyData;
+    private static int highestPositiveByFaculty;
 
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         covidStatsByBlockDataList = new TreeMap<>();
         positiveStatsByFacultyData = new TreeMap<>();
+        highestPositiveByFaculty = 0;
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         List<Person> lastShownList = model.getFilteredPersonList();
@@ -131,6 +133,9 @@ public class SummariseCommand extends Command {
             // Collating this faculty's covid statuses in a TreeMap used for making of PieCharts.
             positiveStatsByFacultyData.put(facultyName, numberOfPositive);
         }
+        if (numberOfPositive > highestPositiveByFaculty) {
+            highestPositiveByFaculty = numberOfPositive;
+        }
         return String.format(FACULTY_SUMMARY_FORM, facultyName, totalNumberOfStudents, numberOfPositive,
                 numberOfNegative, numberOfHrn, percentagePositive);
     }
@@ -200,11 +205,21 @@ public class SummariseCommand extends Command {
     }
 
     /**
-     * Returns true if both tree map are not empty and the pie chart window should be open, returns false otherwise.
+     * Returns true if both tree map are not empty and the pie chart window should be open, returns false otherwise
+     *
      * @return boolean for whether the pie chart window should be opened
      */
     public static boolean shouldOpenPieChartWindow() {
         return !(positiveStatsByFacultyData.isEmpty() && covidStatsByBlockDataList.isEmpty());
+    }
+
+    /**
+     * Returns the highest number of students with Covid categorised by Faculty.
+     *
+     * @return an integer value of the highest number of Covid positive students by Faculty
+     */
+    public static int getHighestPositiveByFaculty() {
+        return highestPositiveByFaculty;
     }
 }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -254,6 +254,7 @@ public class MainWindow extends UiPart<Stage> {
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         emailWindow.hide();
+        pieChartWindow.hide();
         primaryStage.hide();
     }
 

--- a/src/main/java/seedu/address/ui/PieChartWindow.java
+++ b/src/main/java/seedu/address/ui/PieChartWindow.java
@@ -57,11 +57,12 @@ public class PieChartWindow extends UiPart<Stage> {
     }
 
     /**
-     * Organises the data into Pie Charts in a new window.
+     * Organises the data into Charts in a new window.
      */
     private void execute() {
         collateBlocksChart();
         charts.getChildren().add(createFacultyChartPositive());
+        charts.setSpacing(70);
         chartScene = makeChartScene(charts);
         this.getRoot().setScene(chartScene);
     }
@@ -90,13 +91,16 @@ public class PieChartWindow extends UiPart<Stage> {
             return new VBox();
         }
         VBox facChart = new VBox();
+        // Makes the x-axis
         CategoryAxis xAxis = new CategoryAxis();
-        NumberAxis yAxis = new NumberAxis(0, SummariseCommand.getHighestPositiveByFaculty(), 1);
-        BarChart<String, Number> barChart = new BarChart<>(xAxis, yAxis);
-        barChart.setTitle("Covid Positive by Faculty");
         xAxis.setLabel("Faculty");
+        NumberAxis yAxis = new NumberAxis(0, SummariseCommand.getHighestPositiveByFaculty(), 1);
+        // Makes the y-axis
         yAxis.setLabel("Number of Students");
         yAxis.setMinorTickVisible(false);
+        // Combine x-axis and y-axis into a bar chart
+        BarChart<String, Number> barChart = new BarChart<>(xAxis, yAxis);
+        barChart.setTitle("Covid Positive by Faculty");
         barChart.setBarGap(50);
         barChart.setCategoryGap(150);
 
@@ -165,7 +169,7 @@ public class PieChartWindow extends UiPart<Stage> {
      */
     private Scene makeChartScene(VBox pieCharts) {
         ScrollPane sp = new ScrollPane(pieCharts);
-        chartScene = new Scene(sp, 450, 50);
+        chartScene = new Scene(sp, 550, 100);
         return chartScene;
     }
 

--- a/src/main/java/seedu/address/ui/PieChartWindow.java
+++ b/src/main/java/seedu/address/ui/PieChartWindow.java
@@ -132,7 +132,30 @@ public class PieChartWindow extends UiPart<Stage> {
                     statusType.pieValueProperty().getValue()));
             pieChartData.add(statusType);
         }
+        setPieChartColor(pieChartData);
         return pieChart;
+    }
+
+    /**
+     * Sets each pir chart sections to have a specific colour according to their Covid status.
+     * If it represents positive, it is set to red. If it represents negative, it is set to green.
+     * If it represents HRN, it is set to yellowish-gold.
+     *
+     * @param pieChartData The pie chart that will undergo colouring
+     */
+    private void setPieChartColor(ObservableList<PieChart.Data> pieChartData) {
+        for (PieChart.Data data : pieChartData) {
+            String covidType = data.getName();
+            String color = "";
+            if (covidType.contains("Positive")) {
+                color = "-fx-pie-color: red;";
+            } else if (covidType.contains("Negative")) {
+                color = "-fx-pie-color: green;";
+            } else if (covidType.contains("HRN")) {
+                color = "-fx-pie-color: gold;";
+            }
+            data.getNode().setStyle(color);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/PieChartWindow.java
+++ b/src/main/java/seedu/address/ui/PieChartWindow.java
@@ -13,6 +13,7 @@ import javafx.scene.chart.CategoryAxis;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.PieChart;
 import javafx.scene.chart.XYChart;
+import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
@@ -133,6 +134,7 @@ public class PieChartWindow extends UiPart<Stage> {
             pieChartData.add(statusType);
         }
         setPieChartColor(pieChartData);
+        pieChart.setLegendVisible(false);
         return pieChart;
     }
 

--- a/src/main/java/seedu/address/ui/PieChartWindow.java
+++ b/src/main/java/seedu/address/ui/PieChartWindow.java
@@ -93,11 +93,12 @@ public class PieChartWindow extends UiPart<Stage> {
         }
         HBox facChart = new HBox();
         CategoryAxis xAxis = new CategoryAxis();
-        NumberAxis yAxis = new NumberAxis();
+        NumberAxis yAxis = new NumberAxis(0, SummariseCommand.getHighestPositiveByFaculty(), 1);
         BarChart<String, Number> barChart = new BarChart<>(xAxis, yAxis);
         barChart.setTitle("Covid Positive by Faculty");
         xAxis.setLabel("Faculty");
         yAxis.setLabel("Number of Students");
+        yAxis.setMinorTickVisible(false);
         barChart.setBarGap(50);
         barChart.setCategoryGap(150);
 
@@ -183,5 +184,4 @@ public class PieChartWindow extends UiPart<Stage> {
     public void hide() {
         getRoot().hide();
     }
-
 }

--- a/src/main/java/seedu/address/ui/PieChartWindow.java
+++ b/src/main/java/seedu/address/ui/PieChartWindow.java
@@ -13,8 +13,7 @@ import javafx.scene.chart.CategoryAxis;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.PieChart;
 import javafx.scene.chart.XYChart;
-import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
@@ -32,7 +31,7 @@ public class PieChartWindow extends UiPart<Stage> {
     private TreeMap<String, TreeMap<String, Integer>> covidStatsDataByBlocks;
     private PieChart pieChart;
     private Scene chartScene;
-    private HBox charts;
+    private VBox charts;
 
     /**
      * Creates a new PieChartWindow.
@@ -50,7 +49,7 @@ public class PieChartWindow extends UiPart<Stage> {
      */
     public PieChartWindow() {
         this(new Stage());
-        charts = new HBox();
+        charts = new VBox();
         covidStatsDataByBlocks = SummariseCommand.getCovidStatsByBlockDataList();
         covidStatsByBlockData = new TreeMap<>();
         positiveStatsByFacultyData = SummariseCommand.getPositiveStatsByFacultyData();
@@ -62,10 +61,8 @@ public class PieChartWindow extends UiPart<Stage> {
      */
     private void execute() {
         collateBlocksChart();
-        HBox facultyChart = createFacultyChartPositive();
-        VBox allPieCharts = new VBox(charts);
-        allPieCharts.getChildren().add(facultyChart);
-        chartScene = makeChartScene(allPieCharts);
+        charts.getChildren().add(createFacultyChartPositive());
+        chartScene = makeChartScene(charts);
         this.getRoot().setScene(chartScene);
     }
 
@@ -87,12 +84,12 @@ public class PieChartWindow extends UiPart<Stage> {
     /**
      * Creates Bar Chart for hall containing Covid Positive statistics only, by Faculty.
      */
-    private HBox createFacultyChartPositive() {
+    private VBox createFacultyChartPositive() {
         if (positiveStatsByFacultyData.isEmpty()) {
             // No positive students to create chart
-            return new HBox();
+            return new VBox();
         }
-        HBox facChart = new HBox();
+        VBox facChart = new VBox();
         CategoryAxis xAxis = new CategoryAxis();
         NumberAxis yAxis = new NumberAxis(0, SummariseCommand.getHighestPositiveByFaculty(), 1);
         BarChart<String, Number> barChart = new BarChart<>(xAxis, yAxis);
@@ -167,7 +164,8 @@ public class PieChartWindow extends UiPart<Stage> {
      * @return Scene containing the pie chart
      */
     private Scene makeChartScene(VBox pieCharts) {
-        chartScene = new Scene(pieCharts);
+        ScrollPane sp = new ScrollPane(pieCharts);
+        chartScene = new Scene(sp, 450, 50);
         return chartScene;
     }
 

--- a/src/main/resources/view/PieChartWindow.css
+++ b/src/main/resources/view/PieChartWindow.css
@@ -1,0 +1,5 @@
+.default-color0.chart-pie { -fx-pie-color: blue; }
+.default-color1.chart-pie { -fx-pie-color: red; }
+.default-color2.chart-pie { -fx-pie-color: green; }
+.default-color3.chart-pie { -fx-pie-color: yellow; }
+.default-color4.chart-pie { -fx-pie-color: pink; }

--- a/src/main/resources/view/PieChartWindow.fxml
+++ b/src/main/resources/view/PieChartWindow.fxml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
-<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="PieChart" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="450" maxWidth="550" title="Charts" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <scene>
         <Scene>
-            <HBox alignment="CENTER" fx:id="pieChartContainer">
+            <VBox alignment="CENTER" fx:id="pieChartContainer" VBox.vgrow="ALWAYS">
                 <opaqueInsets>
                     <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
                 </opaqueInsets>
                 <padding>
                     <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
                 </padding>
-            </HBox>
+            </VBox>
         </Scene>
     </scene>
 </fx:root>


### PR DESCRIPTION
<img width="1017" alt="Screenshot 2022-04-03 at 4 06 33 PM" src="https://user-images.githubusercontent.com/77206005/161418401-6d74dd20-5e8d-45fe-a91c-b8695ecbd1a0.png">

This PR is in relations to the issues highlighted in the mock Practical Examinations. There are some bugs highlighted by the testers and This version aims to resolve them.

Firstly, to answer issue #218, I have added distinct and fixed colours for the pie charts in the chart window. Red represents positive, green for negative, yellowish-gold for HRN. This is applied to all pie charts so that there is consistency and better to read and understand when someone wants to draw trends from these charts. In addition, the legend for each charts are removed as they are redundant and will just cloud and make the window more hectic.

Secondly, to answer issue #219, The minute intervals in the bar chart will be removed. This makes sure that the intervals only represents integers and not doubles. This is more aligned to the context of the bar graph - representing number of students. The max height of the vertical axis is also subjected to the faculty who has the most number of Covid positive students.

Thirdly, to answer issue #202, #193, #191, #164 and #161, The window opened has been resized to show the pie charts arranged on top of each other. The window can be scrollable too.

Lastly, to answer issue #162, the window will be able to be closed together with the main app window so that the app can be closed nicely.

This is a bug fixing PR and will not cause any major changes to any other PRs or features set in the project.

The purpose of this PR is to receive approval from teammates to allow this bug fixes to be made to the main branch.