### PR TITLE
Added new constraints to name

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -49,7 +49,10 @@ public class ParserUtil {
         requireNonNull(name);
         String trimmedName = name.trim();
         if (!Name.isValidName(trimmedName)) {
-            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS_FORMAT);
+        }
+        if (!Name.isValidNameLength(trimmedName)) {
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS_CHARACTER_LENGTH);
         }
         return new Name(trimmedName);
     }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class Name {
 
     public static final int MAXIMUM_NAME_CHARACTERS_LENGTH = 60;
-    public static final String MESSAGE_CONSTRAINTS_FORMAT=
+    public static final String MESSAGE_CONSTRAINTS_FORMAT =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
     public static final String MESSAGE_CONSTRAINTS_CHARACTER_LENGTH =
             String.format("Names should only not contain more than %d characters", MAXIMUM_NAME_CHARACTERS_LENGTH);

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,8 +16,11 @@ import java.util.List;
  */
 public class Name {
 
-    public static final String MESSAGE_CONSTRAINTS =
+    public static final int MAXIMUM_NAME_CHARACTERS_LENGTH = 60;
+    public static final String MESSAGE_CONSTRAINTS_FORMAT=
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS_CHARACTER_LENGTH =
+            String.format("Names should only not contain more than %d characters", MAXIMUM_NAME_CHARACTERS_LENGTH);
 
     /*
      * The first character of the address must not be a whitespace,
@@ -36,7 +39,7 @@ public class Name {
     public Name(String name) {
         requireNonNull(name);
         searchName = addNameFormat(name);
-        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS_FORMAT);
         fullName = name;
     }
 
@@ -63,6 +66,15 @@ public class Name {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true if a given string is a less than the maximum allowed name characters.
+     *
+     * @param test string to be tested to determine if valid name length in characters.
+     * @return boolean where true if a given string is a valid name in characters, false otherwise.
+     */
+    public static boolean isValidNameLength(String test) {
+        return test.length() < MAXIMUM_NAME_CHARACTERS_LENGTH + 1;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -94,7 +94,7 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
         if (!Name.isValidName(name)) {
-            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS_CHARACTER_LENGTH);
         }
         final Name modelName = new Name(name);
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -94,6 +94,9 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
         if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS_FORMAT);
+        }
+        if (!Name.isValidNameLength(name)) {
             throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS_CHARACTER_LENGTH);
         }
         final Name modelName = new Name(name);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -185,7 +185,7 @@ public class AddCommandParserTest {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + BLOCK_DESC_BOB + FACULTY_DESC_BOB + PHONE_DESC_BOB
                 + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + MATRICULATION_NUMBER_DESC_BOB + COVID_STATUS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS_FORMAT);
 
         // invalid block
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_BLOCK_DESC + FACULTY_DESC_BOB + PHONE_DESC_BOB
@@ -230,7 +230,7 @@ public class AddCommandParserTest {
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + BLOCK_DESC_BOB + FACULTY_DESC_BOB + PHONE_DESC_BOB
                         + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC + MATRICULATION_NUMBER_DESC_BOB + COVID_STATUS_DESC_BOB,
-                Name.MESSAGE_CONSTRAINTS);
+                Name.MESSAGE_CONSTRAINTS_FORMAT);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + BLOCK_DESC_BOB + FACULTY_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -86,7 +86,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS_FORMAT); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
@@ -107,7 +107,7 @@ public class EditCommandParserTest {
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
-                Name.MESSAGE_CONSTRAINTS);
+                Name.MESSAGE_CONSTRAINTS_FORMAT);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -35,6 +35,7 @@ public class ParserUtilTest {
     private static final String VALID_TAG_2 = "neighbour";
 
     private static final String WHITESPACE = " \t\r\n";
+    private static final int MAXIMUM_NAME_CHARACTER_LENGTH = 60;
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
@@ -77,6 +78,33 @@ public class ParserUtilTest {
         String nameWithWhitespace = WHITESPACE + VALID_NAME + WHITESPACE;
         Name expectedName = new Name(VALID_NAME);
         assertEquals(expectedName, ParserUtil.parseName(nameWithWhitespace));
+    }
+
+    @Test
+    public void parseName_validCharacterLength_returnsTrimmedName() throws Exception {
+        String nameWithCharacterLengthOneLessThanMaximum = "";
+        for (int i = 0; i < MAXIMUM_NAME_CHARACTER_LENGTH - 1; i++) {
+            nameWithCharacterLengthOneLessThanMaximum+="a";
+        }
+        Name expectedNameTestCaseOne = new Name(nameWithCharacterLengthOneLessThanMaximum);
+        assertEquals(expectedNameTestCaseOne, ParserUtil.parseName(nameWithCharacterLengthOneLessThanMaximum));
+
+        String nameWithCharacterLengthEqualsToMaximum = "";
+        for (int i = 0; i < MAXIMUM_NAME_CHARACTER_LENGTH; i++) {
+            nameWithCharacterLengthEqualsToMaximum+="a";
+        }
+        Name expectedNameTestCaseTwo = new Name(nameWithCharacterLengthEqualsToMaximum);
+        assertEquals(expectedNameTestCaseTwo, ParserUtil.parseName(nameWithCharacterLengthEqualsToMaximum));
+    }
+
+    @Test
+    public void parseName_invalidCharacterLength_throwsParseException() {
+        String nameWithCharacterLengthOneMoreThanMaximum = "";
+        for (int i = 0; i < MAXIMUM_NAME_CHARACTER_LENGTH + 1; i++) {
+            nameWithCharacterLengthOneMoreThanMaximum+="a";
+        }
+        final String invalidName = nameWithCharacterLengthOneMoreThanMaximum;
+        assertThrows(ParseException.class, () -> ParserUtil.parseName(invalidName));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -84,14 +84,14 @@ public class ParserUtilTest {
     public void parseName_validCharacterLength_returnsTrimmedName() throws Exception {
         String nameWithCharacterLengthOneLessThanMaximum = "";
         for (int i = 0; i < MAXIMUM_NAME_CHARACTER_LENGTH - 1; i++) {
-            nameWithCharacterLengthOneLessThanMaximum+="a";
+            nameWithCharacterLengthOneLessThanMaximum += "a";
         }
         Name expectedNameTestCaseOne = new Name(nameWithCharacterLengthOneLessThanMaximum);
         assertEquals(expectedNameTestCaseOne, ParserUtil.parseName(nameWithCharacterLengthOneLessThanMaximum));
 
         String nameWithCharacterLengthEqualsToMaximum = "";
         for (int i = 0; i < MAXIMUM_NAME_CHARACTER_LENGTH; i++) {
-            nameWithCharacterLengthEqualsToMaximum+="a";
+            nameWithCharacterLengthEqualsToMaximum += "a";
         }
         Name expectedNameTestCaseTwo = new Name(nameWithCharacterLengthEqualsToMaximum);
         assertEquals(expectedNameTestCaseTwo, ParserUtil.parseName(nameWithCharacterLengthEqualsToMaximum));
@@ -101,7 +101,7 @@ public class ParserUtilTest {
     public void parseName_invalidCharacterLength_throwsParseException() {
         String nameWithCharacterLengthOneMoreThanMaximum = "";
         for (int i = 0; i < MAXIMUM_NAME_CHARACTER_LENGTH + 1; i++) {
-            nameWithCharacterLengthOneMoreThanMaximum+="a";
+            nameWithCharacterLengthOneMoreThanMaximum += "a";
         }
         final String invalidName = nameWithCharacterLengthOneMoreThanMaximum;
         assertThrows(ParseException.class, () -> ParserUtil.parseName(invalidName));

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -58,7 +58,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_BLOCK, VALID_FACULTY, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_MATRICULATION_NUMBER, VALID_COVID_STATUS, VALID_TAGS);
-        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        String expectedMessage = Name.MESSAGE_CONSTRAINTS_FORMAT;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -43,6 +43,8 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_MATRICULATION_NUMBER = BENSON.getMatriculationNumber().toString();
     private static final String VALID_COVID_STATUS = BENSON.getStatus().toString();
 
+    private static final int MAXIMUM_NAME_CHARACTER_LENGTH = 60;
+
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -59,6 +61,20 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(INVALID_NAME, VALID_BLOCK, VALID_FACULTY, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_MATRICULATION_NUMBER, VALID_COVID_STATUS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS_FORMAT;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidNameLength_throwsIllegalValueException() {
+        String invalidNameLength = "";
+        for (int i = 0; i < MAXIMUM_NAME_CHARACTER_LENGTH + 1; i++) {
+            invalidNameLength += "a";
+        }
+        final String invalidNameCharacterLength = invalidNameLength;
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(invalidNameCharacterLength, VALID_BLOCK, VALID_FACULTY, VALID_PHONE, VALID_EMAIL,
+                        VALID_ADDRESS, VALID_MATRICULATION_NUMBER, VALID_COVID_STATUS, VALID_TAGS);
+        String expectedMessage = Name.MESSAGE_CONSTRAINTS_CHARACTER_LENGTH;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 


### PR DESCRIPTION
The maximum character length for adding or editing a name is 60. If the character length exceed beyond this limit, an error message will be shown. 

This PR is to address issue #176 

Propose changes to the UG:
instead of a table showing the pre-defined constants, we can also show the restrictions for each field. 
Eg.
Name can only be alphanumerics and contain no more than 60 characters.