### PR TITLE
Fix bug where app cannot close if summarise command is not executed.

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -83,6 +83,7 @@ public class MainWindow extends UiPart<Stage> {
 
         helpWindow = new HelpWindow();
         emailWindow = new EmailWindow(logic.getFilteredPersonList());
+        pieChartWindow = new PieChartWindow();
     }
 
     public Stage getPrimaryStage() {
@@ -270,6 +271,7 @@ public class MainWindow extends UiPart<Stage> {
         if (SummariseCommand.shouldOpenPieChartWindow()) {
             if (pieChartWindow == null || !pieChartWindow.isShowing()) {
                 pieChartWindow = new PieChartWindow();
+                pieChartWindow.execute();
                 pieChartWindow.show();
                 logger.info("Pie chart window is not yet initialised or not showing!");
             } else {

--- a/src/main/java/seedu/address/ui/PieChartWindow.java
+++ b/src/main/java/seedu/address/ui/PieChartWindow.java
@@ -53,13 +53,12 @@ public class PieChartWindow extends UiPart<Stage> {
         covidStatsDataByBlocks = SummariseCommand.getCovidStatsByBlockDataList();
         covidStatsByBlockData = new TreeMap<>();
         positiveStatsByFacultyData = SummariseCommand.getPositiveStatsByFacultyData();
-        execute();
     }
 
     /**
      * Organises the data into Charts in a new window.
      */
-    private void execute() {
+    public void execute() {
         collateBlocksChart();
         charts.getChildren().add(createFacultyChartPositive());
         charts.setSpacing(70);


### PR DESCRIPTION
This PR is a bug fix to PR #232. Previously, if the summarise command was not executed and the user attempts to exit the application, a null pointer exception will be thrown as the PieChartWindow has not been instantiated.

Therefore, this PR fixes this by instantiating an PieChartWindow when the initial constructor for the mainWindow is in-vocated. Subsequent opening and closing will instantiate a new PieChartWindow to retrieve an updated list.

There are no PRs dependent on this.