### PR TITLE
Updated add command to indicate which attributes are not unique

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -46,7 +46,7 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person's %s already exists in the address book";
 
     private final Person toAdd;
 
@@ -63,7 +63,8 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            String nonUniqueAttributeType = model.getNonUniquePersonAttributeType(toAdd);
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_PERSON, nonUniqueAttributeType));
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -72,6 +72,9 @@ public class AddressBook implements ReadOnlyAddressBook {
         return persons.contains(person);
     }
 
+    /**
+     * Returns a string of person attributes that already exists in the address book.
+     */
     public String getNonUniquePersonAttributeType(Person person) {
         requireNonNull(person);
         return persons.getNonUniqueAttributeType(person);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -72,6 +72,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         return persons.contains(person);
     }
 
+    public String getNonUniquePersonAttributeType(Person person) {
+        requireNonNull(person);
+        return persons.getNonUniqueAttributeType(person);
+    }
+
     /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -58,6 +58,12 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns a string of the type of attributes that is unique to a {@code person} that already exist
+     * in the address book.
+     */
+    String getNonUniquePersonAttributeType(Person person);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -94,6 +94,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public String getNonUniquePersonAttributeType(Person person) {
+        requireNonNull(person);
+        return addressBook.getNonUniquePersonAttributeType(person);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.resetOriginal();
         addressBook.saveHistory();

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -20,7 +20,7 @@ public class Name {
     public static final String MESSAGE_CONSTRAINTS_FORMAT =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
     public static final String MESSAGE_CONSTRAINTS_CHARACTER_LENGTH =
-            String.format("Names should only not contain more than %d characters", MAXIMUM_NAME_CHARACTERS_LENGTH);
+            String.format("Names should not contain more than %d characters", MAXIMUM_NAME_CHARACTERS_LENGTH);
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -139,6 +139,7 @@ public class Person {
                 || otherPerson.getMatriculationNumber().equals(getMatriculationNumber())
                 || otherPerson.getEmail().equals(getEmail()));
     }
+
     /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -37,6 +37,37 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns a string of the type of attributes that is unique to a {@code person} that already exist
+     * in the address book.
+     */
+    public String getNonUniqueAttributeType(Person toCheck) {
+        requireNonNull(toCheck);
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < internalList.size(); i++) {
+            Person otherPerson = internalList.get(i);
+            if (otherPerson.isSamePerson(toCheck)) {
+                if (otherPerson.getPhone().equals(toCheck.getPhone()) && !stringBuilder.toString().contains("Phone")) {
+                    stringBuilder.append("Phone");
+                }
+                if (otherPerson.getMatriculationNumber().equals(toCheck.getMatriculationNumber())
+                        && !stringBuilder.toString().contains("Matriculation Number")) {
+                    if (!stringBuilder.toString().isEmpty()) {
+                        stringBuilder.append(", ");
+                    }
+                    stringBuilder.append("Matriculation Number");
+                }
+                if (otherPerson.getEmail().equals(toCheck.getEmail()) && !stringBuilder.toString().contains("Email")) {
+                    if (!stringBuilder.toString().isEmpty()) {
+                        stringBuilder.append(" and ");
+                    }
+                    stringBuilder.append("Email");
+                }
+            }
+        }
+        return stringBuilder.toString();
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -45,26 +45,55 @@ public class UniquePersonList implements Iterable<Person> {
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < internalList.size(); i++) {
             Person otherPerson = internalList.get(i);
-            if (otherPerson.isSamePerson(toCheck)) {
-                if (otherPerson.getPhone().equals(toCheck.getPhone()) && !stringBuilder.toString().contains("Phone")) {
-                    stringBuilder.append("Phone");
+            if (otherPerson.isSamePerson(toCheck)) { // Unique attributes already exist in the address book.
+                if (otherPerson.getPhone().equals(toCheck.getPhone())) {
+                    appendPhoneAttributeToString(stringBuilder);
                 }
-                if (otherPerson.getMatriculationNumber().equals(toCheck.getMatriculationNumber())
-                        && !stringBuilder.toString().contains("Matriculation Number")) {
-                    if (!stringBuilder.toString().isEmpty()) {
-                        stringBuilder.append(", ");
-                    }
-                    stringBuilder.append("Matriculation Number");
+                if (otherPerson.getMatriculationNumber().equals(toCheck.getMatriculationNumber())) {
+                    appendMatriculationNumberAttributeToString(stringBuilder);
                 }
-                if (otherPerson.getEmail().equals(toCheck.getEmail()) && !stringBuilder.toString().contains("Email")) {
-                    if (!stringBuilder.toString().isEmpty()) {
-                        stringBuilder.append(" and ");
-                    }
-                    stringBuilder.append("Email");
+                if (otherPerson.getEmail().equals(toCheck.getEmail())) {
+                    appendEmailAttributeToString(stringBuilder);
                 }
             }
         }
         return stringBuilder.toString();
+    }
+
+    /**
+     * Appends the necessary syntax for the Phone attribute into the non-unique attribute type string.
+     * @param stringBuilder Non-unique attribute type string
+     */
+    private void appendPhoneAttributeToString(StringBuilder stringBuilder) {
+        if (!stringBuilder.toString().contains("Phone")) {
+            stringBuilder.append("Phone");
+        }
+    }
+
+    /**
+     * Appends the necessary syntax for the Matriculation Number attribute into the non-unique attribute type string.
+     * @param stringBuilder Non-unique attribute type string
+     */
+    private void appendMatriculationNumberAttributeToString(StringBuilder stringBuilder) {
+        if (!stringBuilder.toString().contains("Matriculation Number")) {
+            if (!stringBuilder.toString().isEmpty()) {
+                stringBuilder.append(", ");
+            }
+            stringBuilder.append("Matriculation Number");
+        }
+    }
+
+    /**
+     * Appends the necessary syntax for the Email attribute into the non-unique attribute type string.
+     * @param stringBuilder Non-unique attribute type string
+     */
+    private void appendEmailAttributeToString(StringBuilder stringBuilder) {
+        if (!stringBuilder.toString().contains("Email")) {
+            if (!stringBuilder.toString().isEmpty()) {
+                stringBuilder.append(" and ");
+            }
+            stringBuilder.append("Email");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -39,7 +39,8 @@ public class AddCommandIntegrationTest {
     @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
-        assertCommandFailure(new AddCommand(personInList), model, AddCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(new AddCommand(personInList), model,
+                String.format(AddCommand.MESSAGE_DUPLICATE_PERSON, "Phone, Matriculation Number and Email"));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -52,7 +52,8 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, String.format(AddCommand.MESSAGE_DUPLICATE_PERSON,
+            "DUPLICATE ATTRIBUTE"), () -> addCommand.execute(modelStub));
     }
 
     @Test
@@ -194,6 +195,12 @@ public class AddCommandTest {
         public boolean hasPerson(Person person) {
             requireNonNull(person);
             return this.person.isSamePerson(person);
+        }
+
+        @Override
+        public String getNonUniquePersonAttributeType(Person person) {
+            requireNonNull(person);
+            return "DUPLICATE ATTRIBUTE";
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -124,6 +124,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public String getNonUniquePersonAttributeType(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ReadOnlyAddressBook getAddressBook() {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
The add command will now throw an error message indicating which attributes are not unique or already exist in the address book so that the user will have a better idea on which attribute needs to be change. 

This PR address issue #186 #190 

All three fields not unique
![image](https://user-images.githubusercontent.com/68064689/161433416-0182c2a0-a43f-41b9-aee5-b915364e1727.png)
MN and email not unique
![image](https://user-images.githubusercontent.com/68064689/161433423-5700c919-a9c9-43f8-83e2-d2527f0c3ecf.png)
Email not unique
![image](https://user-images.githubusercontent.com/68064689/161433431-f6278190-7671-41db-b567-d74f03ce35c6.png)
MN not unique
![image](https://user-images.githubusercontent.com/68064689/161433441-3c47bd34-b88f-4697-982c-927c817f0cd7.png)
Phone and MN not unique
![image](https://user-images.githubusercontent.com/68064689/161433449-2bbc9b13-da39-4402-a134-025451be8cce.png)
Phone not unique
![image](https://user-images.githubusercontent.com/68064689/161433521-db5d2fe1-1761-4e7f-8ca5-eda5ddbdb699.png)
