### PR TITLE
Update the method for the non-unique attribute type message

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -13,6 +13,9 @@ import seedu.address.model.tag.Tag;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Person {
+
+    public static final String[] UNIQUE_ATTRIBUTE_TYPES = {"Phone", "Email", "Matriculation Number"};
+
     // Identity fields
     private final Name name;
     private final Block block;

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -68,7 +68,8 @@ public class UniquePersonList implements Iterable<Person> {
      * @param uniqueAttributeTypesIndex The index of the unique attributes specified by the {@code Person} class
      */
     private void addNonUniqueAttributeType(ArrayList<String> nonUniqueAttributeTypes, int uniqueAttributeTypesIndex) {
-        assert uniqueAttributeTypesIndex >= 0 && uniqueAttributeTypesIndex <= 2 : false;
+        assert uniqueAttributeTypesIndex >= 0 && uniqueAttributeTypesIndex <= Person.UNIQUE_ATTRIBUTE_TYPES.length
+            : false;
         String attributeType = Person.UNIQUE_ATTRIBUTE_TYPES[uniqueAttributeTypesIndex];
         if (!nonUniqueAttributeTypes.contains(attributeType)) {
             nonUniqueAttributeTypes.add(attributeType);
@@ -76,51 +77,35 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Returns the message for non-unique attribute types. This message needs further processing as there is a
-     * white space before a comma.
+     * Returns the message for non-unique attribute types.
      *
      * @param nonUniqueAttributeTypes The types of non-unique attribute
      */
-    private String getNonUniqueAttributeTypesMessage(ArrayList<String> nonUniqueAttributeTypes) {
+    public String getNonUniqueAttributeTypesMessage(ArrayList<String> nonUniqueAttributeTypes) {
         if (nonUniqueAttributeTypes.isEmpty()) {
             return "";
         }
-        StringBuilder stringBuilder = new StringBuilder(); // to store all the non-unique attribute types
+        StringBuilder message = new StringBuilder(); // to store all the non-unique attribute types
         if (nonUniqueAttributeTypes.size() == 1) { // only have one non-unique attribute types
-            stringBuilder.append(nonUniqueAttributeTypes.get(0));
-            return stringBuilder.toString();
+            message.append(nonUniqueAttributeTypes.get(0));
+            return message.toString();
+        } else if (nonUniqueAttributeTypes.size() == 2) {
+            message.append(nonUniqueAttributeTypes.get(0) + " and ");
+            message.append(nonUniqueAttributeTypes.get(1));
         } else {
             for (int i = 0; i < nonUniqueAttributeTypes.size(); i++) {
                 if (i == 0) { // first attribute type in the list
-                    stringBuilder.append(nonUniqueAttributeTypes.get(0) + " ");
+                    message.append(nonUniqueAttributeTypes.get(0));
                 } else if (i + 1 == nonUniqueAttributeTypes.size()) { // last attribute type in the list
-                    stringBuilder.append("and ");
-                    stringBuilder.append(nonUniqueAttributeTypes.get(i));
+                    message.append("and ");
+                    message.append(nonUniqueAttributeTypes.get(i));
                 } else { // neither first nor last
-                    stringBuilder.append(", ");
-                    stringBuilder.append(nonUniqueAttributeTypes.get(i) + " ");
+                    message.append(", ");
+                    message.append(nonUniqueAttributeTypes.get(i) + " ");
                 }
             }
         }
-        return removeWhiteSpaceBeforeComma(stringBuilder);
-    }
-
-    /**
-     * Removes white space before a comma for the non-unique attribute type message.
-     *
-     * @param stringBuilder The non-unique attribute type message with a whitespace before comma
-     * @return Trimmed non-unique attribute type message
-     */
-    private String removeWhiteSpaceBeforeComma(StringBuilder stringBuilder) {
-        StringBuilder stringBuilderTrimmed = new StringBuilder();
-        String message = stringBuilder.toString();
-        for (int i = 0; i < message.length(); i++) {
-            // if there is no white space before a comma
-            if (!(message.charAt(i) == ' ' && message.charAt(i + 1) == ',')) {
-                stringBuilderTrimmed.append(message.charAt(i));
-            }
-        }
-        return stringBuilderTrimmed.toString();
+        return message.toString();
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -17,7 +18,7 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
  * persons uses Person#isSamePerson(Person) for equality so as to ensure that the person being added or updated is
  * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) so
  * as to ensure that the person with exactly the same fields will be removed.
- *
+ * <p>
  * Supports a minimal set of list operations.
  *
  * @see Person#isSamePerson(Person)
@@ -42,58 +43,84 @@ public class UniquePersonList implements Iterable<Person> {
      */
     public String getNonUniqueAttributeType(Person toCheck) {
         requireNonNull(toCheck);
-        StringBuilder stringBuilder = new StringBuilder();
+        ArrayList<String> nonUniqueAttributeTypes = new ArrayList<>();
         for (int i = 0; i < internalList.size(); i++) {
             Person otherPerson = internalList.get(i);
             if (otherPerson.isSamePerson(toCheck)) { // Unique attributes already exist in the address book.
                 if (otherPerson.getPhone().equals(toCheck.getPhone())) {
-                    appendPhoneAttributeToString(stringBuilder);
-                }
-                if (otherPerson.getMatriculationNumber().equals(toCheck.getMatriculationNumber())) {
-                    appendMatriculationNumberAttributeToString(stringBuilder);
+                    addNonUniqueAttributeType(nonUniqueAttributeTypes, 0);
                 }
                 if (otherPerson.getEmail().equals(toCheck.getEmail())) {
-                    appendEmailAttributeToString(stringBuilder);
+                    addNonUniqueAttributeType(nonUniqueAttributeTypes, 1);
+                }
+                if (otherPerson.getMatriculationNumber().equals(toCheck.getMatriculationNumber())) {
+                    addNonUniqueAttributeType(nonUniqueAttributeTypes, 2);
                 }
             }
         }
-        return stringBuilder.toString();
+        return getNonUniqueAttributeTypesMessage(nonUniqueAttributeTypes);
     }
 
     /**
-     * Appends the necessary syntax for the Phone attribute into the non-unique attribute type string.
-     * @param stringBuilder Non-unique attribute type string
+     * Adds a non-unique attribute type to the list if it is not yet added.
+     *
+     * @param nonUniqueAttributeTypes   The list containing the non-unique attribute types
+     * @param uniqueAttributeTypesIndex The index of the unique attributes specified by the {@code Person} class
      */
-    private void appendPhoneAttributeToString(StringBuilder stringBuilder) {
-        if (!stringBuilder.toString().contains("Phone")) {
-            stringBuilder.append("Phone");
+    private void addNonUniqueAttributeType(ArrayList<String> nonUniqueAttributeTypes, int uniqueAttributeTypesIndex) {
+        assert uniqueAttributeTypesIndex >= 0 && uniqueAttributeTypesIndex <= 2 : false;
+        String attributeType = Person.UNIQUE_ATTRIBUTE_TYPES[uniqueAttributeTypesIndex];
+        if (!nonUniqueAttributeTypes.contains(attributeType)) {
+            nonUniqueAttributeTypes.add(attributeType);
         }
     }
 
     /**
-     * Appends the necessary syntax for the Matriculation Number attribute into the non-unique attribute type string.
-     * @param stringBuilder Non-unique attribute type string
+     * Returns the message for non-unique attribute types. This message needs further processing as there is a
+     * white space before a comma.
+     *
+     * @param nonUniqueAttributeTypes The types of non-unique attribute
      */
-    private void appendMatriculationNumberAttributeToString(StringBuilder stringBuilder) {
-        if (!stringBuilder.toString().contains("Matriculation Number")) {
-            if (!stringBuilder.toString().isEmpty()) {
-                stringBuilder.append(", ");
+    private String getNonUniqueAttributeTypesMessage(ArrayList<String> nonUniqueAttributeTypes) {
+        if (nonUniqueAttributeTypes.isEmpty()) {
+            return "";
+        }
+        StringBuilder stringBuilder = new StringBuilder(); // to store all the non-unique attribute types
+        if (nonUniqueAttributeTypes.size() == 1) { // only have one non-unique attribute types
+            stringBuilder.append(nonUniqueAttributeTypes.get(0));
+            return stringBuilder.toString();
+        } else {
+            for (int i = 0; i < nonUniqueAttributeTypes.size(); i++) {
+                if (i == 0) { // first attribute type in the list
+                    stringBuilder.append(nonUniqueAttributeTypes.get(0) + " ");
+                } else if (i + 1 == nonUniqueAttributeTypes.size()) { // last attribute type in the list
+                    stringBuilder.append("and ");
+                    stringBuilder.append(nonUniqueAttributeTypes.get(i));
+                } else { // neither first nor last
+                    stringBuilder.append(", ");
+                    stringBuilder.append(nonUniqueAttributeTypes.get(i) + " ");
+                }
             }
-            stringBuilder.append("Matriculation Number");
         }
+        return removeWhiteSpaceBeforeComma(stringBuilder);
     }
 
     /**
-     * Appends the necessary syntax for the Email attribute into the non-unique attribute type string.
-     * @param stringBuilder Non-unique attribute type string
+     * Removes white space before a comma for the non-unique attribute type message.
+     *
+     * @param stringBuilder The non-unique attribute type message with a whitespace before comma
+     * @return Trimmed non-unique attribute type message
      */
-    private void appendEmailAttributeToString(StringBuilder stringBuilder) {
-        if (!stringBuilder.toString().contains("Email")) {
-            if (!stringBuilder.toString().isEmpty()) {
-                stringBuilder.append(" and ");
+    private String removeWhiteSpaceBeforeComma(StringBuilder stringBuilder) {
+        StringBuilder stringBuilderTrimmed = new StringBuilder();
+        String message = stringBuilder.toString();
+        for (int i = 0; i < message.length(); i++) {
+            // if there is no white space before a comma
+            if (!(message.charAt(i) == ' ' && message.charAt(i + 1) == ',')) {
+                stringBuilderTrimmed.append(message.charAt(i));
             }
-            stringBuilder.append("Email");
         }
+        return stringBuilderTrimmed.toString();
     }
 
     /**
@@ -173,7 +200,7 @@ public class UniquePersonList implements Iterable<Person> {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof UniquePersonList // instanceof handles nulls
-                        && internalList.equals(((UniquePersonList) other).internalList));
+                && internalList.equals(((UniquePersonList) other).internalList));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -40,7 +40,7 @@ public class AddCommandIntegrationTest {
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
         assertCommandFailure(new AddCommand(personInList), model,
-                String.format(AddCommand.MESSAGE_DUPLICATE_PERSON, "Phone, Matriculation Number and Email"));
+                String.format(AddCommand.MESSAGE_DUPLICATE_PERSON, "Phone, Email and Matriculation Number"));
     }
 
 }

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -169,5 +170,47 @@ public class UniquePersonListTest {
     public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, ()
             -> uniquePersonList.asUnmodifiableObservableList().remove(0));
+    }
+
+    @Test
+    public void getNonUniqueAttributeTypesMessage() {
+        String nonUniquePhoneMessage = "Phone";
+        String nonUniqueEmailMessage = "Email";
+        String nonUniqueMatriculationNumberMessage = "Matriculation Number";
+        String nonUniquePhoneAndEmailMessage = "Phone and Email";
+        String nonUniquePhoneAndMatriculationNumberMessage = "Phone and Matriculation Number";
+        String nonUniqueEmailAndMatriculationNumberMessage = "Email and Matriculation Number";
+        String nonUniqueAllMessage = "Phone, Email and Matriculation Number";
+        UniquePersonList uniquePersonList = new UniquePersonList();
+        ArrayList<String> arrayList = new ArrayList<>();
+        // case 1: non-unique phone message
+        arrayList.add("Phone");
+        assertEquals(nonUniquePhoneMessage, uniquePersonList.getNonUniqueAttributeTypesMessage(arrayList));
+        arrayList.clear();
+        arrayList.add("Email");
+        assertEquals(nonUniqueEmailMessage, uniquePersonList.getNonUniqueAttributeTypesMessage(arrayList));
+        arrayList.clear();
+        arrayList.add("Matriculation Number");
+        assertEquals(nonUniqueMatriculationNumberMessage,
+                uniquePersonList.getNonUniqueAttributeTypesMessage(arrayList));
+        arrayList.clear();
+        arrayList.add("Phone");
+        arrayList.add("Email");
+        assertEquals(nonUniquePhoneAndEmailMessage, uniquePersonList.getNonUniqueAttributeTypesMessage(arrayList));
+        arrayList.clear();
+        arrayList.add("Phone");
+        arrayList.add("Matriculation Number");
+        assertEquals(nonUniquePhoneAndMatriculationNumberMessage,
+                uniquePersonList.getNonUniqueAttributeTypesMessage(arrayList));
+        arrayList.clear();
+        arrayList.add("Email");
+        arrayList.add("Matriculation Number");
+        assertEquals(nonUniqueEmailAndMatriculationNumberMessage,
+                uniquePersonList.getNonUniqueAttributeTypesMessage(arrayList));
+        arrayList.clear();
+        arrayList.add("Phone");
+        arrayList.add("Email");
+        arrayList.add("Matriculation Number");
+        assertEquals(nonUniqueAllMessage, uniquePersonList.getNonUniqueAttributeTypesMessage(arrayList));
     }
 }


### PR DESCRIPTION
This PR addresses issue #260 

The message for any non-unique attribute types will now display correctly.

![image](https://user-images.githubusercontent.com/68064689/161800462-575afdb2-3abd-41d3-8412-ef891e994938.png)
![image](https://user-images.githubusercontent.com/68064689/161800821-b8e9cca7-ec13-4a51-b631-372d0e85e0f8.png)


This new method will also work for any new fields that needs to be unique.

This PR is for review and can be merged subsequently if there is no error or suggestions.